### PR TITLE
Add cdk-service-kicker to layer index

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ List of Base Layers
 | [beats-base](https://github.com/juju-solutions/layer-beats-base) | Beats Base | Base layer for Elastic Beats |
 | [bigtop-base](https://github.com/juju-solutions/layer-apache-bigtop-base.git) | Apache Bigtop Base Layer | Base layer for charms needing Apache Bigtop  |
 | [buildpacks](https://git.launchpad.net/~bcsaller/charms/+source/buildpacks) | Buildpacks | Experimental layer for using buildpacks to generate Charmed applications |
+| [cdk-service-kicker](https://github.com/juju-solutions/layer-cdk-service-kicker.git) | CDK Service Kicker | Installs a background service, cdk-service-kicker, for kicking cdk services. |
 | [ceph-base](https://github.com/ChrisMacNaughton/layer-ceph-base) | EXPERIMENTAL Ceph Base Layer | EXPERIMENTAL Ceph base layer |
 | [ceph-basic](https://github.com/ChrisMacNaughton/layer-ceph-basic) | EXPERIMENTAL ceph-basic | EXPERIMENTAL ceph-basic layer |
 | [ceph-mon](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon) | EXPERIMENTAL Ceph Mon layer | EXPERIMENTAL Ceph Mon layer |

--- a/layers/cdk-service-kicker.json
+++ b/layers/cdk-service-kicker.json
@@ -1,0 +1,6 @@
+{
+  "id": "cdk-service-kicker",
+  "name": "CDK Service Kicker",
+  "repo": "https://github.com/juju-solutions/layer-cdk-service-kicker.git",
+  "summary": "Installs a background service, cdk-service-kicker, for kicking cdk services."
+}


### PR DESCRIPTION
See https://github.com/juju-solutions/layer-cdk-service-kicker.

Yeah, this layer's pretty nuts. But we need it for the etcd, kubernetes-master, and kubernetes-worker charms.