### PR TITLE
Move prometheus interface to LP

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ List of Interface Layers
 | [pgsql](https://git.launchpad.net/interface-pgsql) | pgsql | Postgresql database client interface |
 | [platformmaster](https://launchpad.net/~ibmcharmers/interface-ibm-platformmaster/trunk) | platformmaster | This interface layer handles the communication between Platform Master (like IBM Platform LSF, IBM Spectrum Symphony) and Platform Server/Nodes. |
 | [postgresql-stats](https://github.com/jamesbeedy/interface-postgresql-stats.git) | Postgresql Stats | Interface for integrating with metrics gathering layers |
-| [prometheus](https://github.com/tasdomas/juju-interface-prometheus.git) | prometheus | Prometheus target interface |
+| [prometheus](https://git.launchpad.net/interface-prometheus) | prometheus | Prometheus target interface |
 | [public-address](https://github.com/juju-solutions/interface-public-address) | public-address | Simple relation that provides the providers public-address and a port |
 | [rabbitmq](https://github.com/openstack/charm-interface-rabbitmq) | rabbitmq | RabbitMQ AMQP interface |
 | [redis-stats](https://github.com/jamesbeedy/interface-redis-stats.git) | Redis Stats | Interface to be used for integration with metrics gathering layers |

--- a/interfaces/prometheus.json
+++ b/interfaces/prometheus.json
@@ -1,6 +1,6 @@
 {
   "id": "prometheus",
   "name": "prometheus",
-  "repo": "https://github.com/tasdomas/juju-interface-prometheus.git",
+  "repo": "https://git.launchpad.net/interface-prometheus",
   "summary": "Prometheus target interface"
 }


### PR DESCRIPTION
We agreed with @tasdomas that's it's best if the prometheus interface is hosted next to the prometheus charm.
I pushed code to Launchpad, this PR will update repo location.