### PR TITLE
add prometheus-rules interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ List of Interface Layers
 | [pgsql](https://git.launchpad.net/interface-pgsql) | pgsql | Postgresql database client interface |
 | [platformmaster](https://launchpad.net/~ibmcharmers/interface-ibm-platformmaster/trunk) | platformmaster | This interface layer handles the communication between Platform Master (like IBM Platform LSF, IBM Spectrum Symphony) and Platform Server/Nodes. |
 | [prometheus](https://git.launchpad.net/interface-prometheus) | prometheus | Prometheus target interface |
+| [prometheus-rules](https://github.com/CanonicalBootStack/interface-prometheus-rules.git) | prometheus-rules | Prometheus alerting rules target interface |
 | [public-address](https://github.com/juju-solutions/interface-public-address) | public-address | Simple relation that provides the providers public-address and a port |
 | [rabbitmq](https://github.com/openstack/charm-interface-rabbitmq) | rabbitmq | RabbitMQ AMQP interface |
 | [redis](https://github.com/omnivector-solutions/interface-redis) | redis | Interface for relating to redis |

--- a/interfaces/prometheus-rules.json
+++ b/interfaces/prometheus-rules.json
@@ -1,0 +1,6 @@
+{
+  "id": "prometheusi-rules",
+  "name": "prometheus-rules",
+  "repo": "https://github.com/CanonicalBootStack/interface-prometheus-rules.git",
+  "summary": "Relation Stub to export Prometheus alerting rules"
+}


### PR DESCRIPTION
Adds an interface used to transfer alerting rules between charms, e.g. Telegraf, and the Prometheus charm.