### PR TITLE
Interface-keystone-admin is on github

### DIFF
--- a/interfaces/keystone-admin.json
+++ b/interfaces/keystone-admin.json
@@ -1,6 +1,6 @@
 {
   "id": "keystone-admin",
   "name": "keystone-admin",
-  "repo": "https://git.launchpad.net/~canonical-is/charms/+source/interface-keystone-admin",
+  "repo": "https://github.com/openstack/charm-interface-keystone-admin",
   "summary": "keystone-admin:identity-admin interface to use shared admin API credentials"
 }


### PR DESCRIPTION
Interface-keystone-admin is an official OpenStack upstream project
hosted on github and manged by gerrit. Update the layer index repo to
point to github.