### PR TITLE
Add ``dashboard-plugin`` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ List of Interface Layers
 | [consul-agent](https://github.com/ChrisMacNaughton/juju-interface-consul.git) | consul-agent | Hashicorp Consul |
 | [consul](https://github.com/juju-solutions/interface-consul) | consul | Hashicorp Consul |
 | [cwr-ci](https://github.com/juju-solutions/interface-cwr-ci.git) | cwr-ci | Interface for relating to Cloud Weather Report (part of the Juju CI system) |
+| [dashboard-plugin](https://github.com/openstack-charmers/charm-interface-dashboard-plugin.git) | dashboard-plugin | This interface is for use with OpenStack Dashboard plugin subordinate charms |
 | [db-info](https://github.com/omnivector-solutions/interface-db-info) | DB Info | Ease the process of application <-> application database creds transference. |
 | [db2](https://launchpad.net/~ibmcharmers/interface-ibm-db2/trunk) | db2 | This interface layer handles the communication between  IBM DB2 and Consumer charms. |
 | [dbname](https://github.com/omnivector-solutions/interface-dbname.git) | DB Name | Interface to coordinate database name between applications. |

--- a/interfaces/dashboard-plugin.json
+++ b/interfaces/dashboard-plugin.json
@@ -1,0 +1,6 @@
+{
+  "id": "dashboard-plugin",
+  "name": "dashboard-plugin",
+  "repo": "https://github.com/openstack/charm-interface-dashboard-plugin.git",
+  "summary": "This interface is for use with OpenStack Dashboard plugin subordinate charms"
+}


### PR DESCRIPTION
This interface is for use with OpenStack Dashboard plugin
subordinate charms.

I am aware of that the name might be percieved as a bit
ambigious, but the interface is created after the fact to
support long lived and in the wild running code [0].

0: https://github.com/openstack/charm-openstack-dashboard/blob/ab7871c793a51d41fec2ed8fccdb2384caec8a45/metadata.yaml#L24