### PR TITLE
Add explicit repo and docs links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ file.  Specifically, it must contain at least the following fields:
 * `repo`: The URL of the git or bzr repo for the layer
 * `summary`: A short description of the purpose of the layer
 
+The file can also contain a `docs` field, which can specify a link to documentation
+for the layer.  If not specified, a link to a `README.md` file will be generated,
+if the repo is hosted on GitHub or Launchpad, or the link to the repo will be used.
+
 The name of the file must match the ID field, with a `.json` suffix.
 
 To add or modify a layer in the index, just create a PR against this repo in
@@ -38,97 +42,97 @@ List of Base Layers
 
 <!-- list-of-layers -->
 
-| ID | Name | Summary |
-| --- | --- | --- |
-| [ansible-base](https://github.com/chuckbutler/ansible-base) | ansible-base | Base / charm layer for charming w/ Ansible |
-| [apache-bigtop-base](https://github.com/juju-solutions/layer-apache-bigtop-base.git) | Apache Bigtop Base Layer | Base layer for charms needing Apache Bigtop  |
-| [apache-bigtop-gateway](https://github.com/juju-solutions/layer-apache-bigtop-gateway) | apache-bigtop-gateway | Base layer for Gateway node from Apache Big Top |
-| [apache-flume-base](https://github.com/juju-solutions/layer-apache-flume-base.git) | Apache Flume Base | Base layer for Apache Flume charms |
-| [apache-hadoop-datanode](https://github.com/juju-solutions/layer-apache-hadoop-datanode.git) | Apache Hadoop DataNode | Base / charm layer for the DataNode component of Hadoop |
-| [apache-hadoop-namenode](https://github.com/juju-solutions/layer-apache-hadoop-namenode.git) | Apache Hadoop NameNode | Charm layer for the NameNode component of Hadoop |
-| [apache-hadoop-nodemanager](https://github.com/juju-solutions/layer-apache-hadoop-nodemanager.git) | Apache Hadoop NodeManager | Base / charm layer for the NodeManager component of Hadoop |
-| [apache-hadoop-plugin](https://github.com/juju-solutions/layer-apache-hadoop-plugin.git) | apache-hadoop-plugin | Simplified connection point for Apache Hadoop platform |
-| [apache-hadoop-resourcemanager](https://github.com/juju-solutions/layer-apache-hadoop-resourcemanager.git) | Apache Hadoop ResourceManager | Charm layer for the ResourceManager component of Hadoop |
-| [apache-hadoop-slave](https://github.com/juju-solutions/layer-apache-hadoop-slave.git) | apache-hadoop-slave | Combined slave node (DataNode + NodeManager) for Apache Hadoop |
-| [apache-php](https://github.com/juju-solutions/layer-apache-php.git) | Apache PHP base layer | Configurable base for Apache PHP charms |
-| [apache-wsgi](https://git.launchpad.net/~jacekn/charms/+source/apache-wsgi) | Apache WSGI base layer | Configurable base for Apache WSGI charms |
-| [apt](https://git.launchpad.net/layer-apt) | Apt layer | Easily deal with apt sources and deb packages |
-| [barbican-client](https://github.com/omnivector-solutions/layer-barbican-client) | Barbican Client | Reactive layer to help pull secrets from barbican |
-| [basic](https://github.com/juju-solutions/layer-basic.git) | Basic Layer | Base layer for charms with the Reactive framework |
-| [beats-base](https://github.com/juju-solutions/layer-beats-base) | Beats Base | Base layer for Elastic Beats |
-| [bigtop-base](https://github.com/juju-solutions/layer-apache-bigtop-base.git) | Apache Bigtop Base Layer | Base layer for charms needing Apache Bigtop  |
-| [buildpacks](https://git.launchpad.net/~bcsaller/charms/+source/buildpacks) | Buildpacks | Experimental layer for using buildpacks to generate Charmed applications |
-| [caas-base](https://github.com/juju-solutions/layer-caas-base.git) | Base Layer for CAAS charms | Base layer for CAAS charms with the Reactive framework |
-| [cdk-service-kicker](https://github.com/juju-solutions/layer-cdk-service-kicker.git) | CDK Service Kicker | Installs a background service, cdk-service-kicker, for kicking cdk services. |
-| [ceph-base](https://github.com/ChrisMacNaughton/layer-ceph-base) | EXPERIMENTAL Ceph Base Layer | EXPERIMENTAL Ceph base layer |
-| [ceph-basic](https://github.com/ChrisMacNaughton/layer-ceph-basic) | EXPERIMENTAL ceph-basic | EXPERIMENTAL ceph-basic layer |
-| [ceph-mon](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon) | EXPERIMENTAL Ceph Mon layer | EXPERIMENTAL Ceph Mon layer |
-| [charmscaler-base](https://github.com/elastisys/layer-charmscaler-base) | Charmscaler Base | Charmscaler base layer |
-| [conda-api](https://github.com/omnivector-solutions/layer-conda-api) | Conda API | Conda API layer |
-| [consul-base](https://github.com/omnivector-solutions/layer-consul-base) | Consul Base | Reactive base layer for consul |
-| [coordinator](https://git.launchpad.net/layer-coordinator ) | Coordinator Layer | Coordinate operations between units in a service, such as rolling restarts. |
-| [debug](https://github.com/juju-solutions/layer-debug.git) | debug | Provides a troubleshooting debug action |
-| [django](https://github.com/marcoceppi/layer-django.git) | Django | Django / GUNICORN |
-| [docker-resource](https://github.com/juju-solutions/layer-docker-resource.git) | Docker Resource Layer | Layer for managing charm resources of type 'docker' |
-| [docker](https://github.com/juju-solutions/layer-docker.git) | Docker | Layer to deliver and install Docker on Ubuntu, Debian, Centos hosts. |
-| [elastic-base](https://github.com/omnivector-solutions/layer-elastic-base.git) | Elastic-Base | Base layer for Elastic.co charms |
-| [elasticsearch-client](https://github.com/omnivector-solutions/layer-elasticsearch-client) | Elasticsearch Client | Elasticsearch client layer |
-| [elixir](https://github.com/battlemidget/juju-layer-elixir.git) | Elixir | Runtime layer for Elixir applications |
-| [flannel](https://github.com/juju-solutions/layer-flannel) | Flannel | Flannel Overlay Network layer for docker |
-| [flask](https://github.com/tengu-team/layer-flask) | Flask | Layer to create Flask webservers running on nginx |
-| [git-deploy](https://github.com/omnivector-solutions/layer-git-deploy.git) | Git Deploy | Layer to aid with deploying code from github |
-| [go-binary](https://github.com/cloud-green/go-binary-layer) | Go Binary Base Layer | Takes a statically compiled go binary and starts it as a service |
-| [hadoop-base](https://github.com/juju-solutions/layer-hadoop-base.git) | Hadoop Base | Base layer for a charm needing the Apache Hadoop libraries |
-| [hadoop-client](https://github.com/juju-solutions/layer-hadoop-client.git) | hadoop-client | Base and charm layer for Hadoop clients |
-| [hadoop-datanode](https://github.com/juju-solutions/layer-hadoop-datanode) | hadoop-datanode | Base layer for DataNode from Apache BigTop |
-| [hadoop-ganglia](https://github.com/juju-solutions/layer-hadoop-ganglia.git) | hadoop-ganglia | Base layer for adding Ganglia support to Hadoop core charms |
-| [hadoop-nodemanager](https://github.com/juju-solutions/layer-hadoop-nodemanager) | hadoop-nodemanager | Base layer for NodeManager from Apache BigTop |
-| [haproxy-core](https://github.com/juju-solutions/layer-haproxy-core.git) | haproxy-core | A reactive layer that delivers a minimal haproxy layer to use in other application layers. |
-| [hhvm](https://github.com/battlemidget/juju-layer-hhvm) | HHVM | Provides HHVM and composer for php applications |
-| [ibm-base](https://code.launchpad.net/~ibmcharmers/layer-ibm-base/trunk) | IBM Base Layer | Base layer for IBM charms |
-| [ibm-im](http://launchpad.net/~ibmcharmers/ibmlayers/layer-ibm-im) | IBM IM | This layer provides IBM Installation Manager, which can be used to install many IBM products. |
-| [ibm-was-nd](https://code.launchpad.net/~ibmcharmers/charms/trusty/layer-ibm-was-nd/trunk) | IBM WAS ND | Charm layer for IBM WAS ND DM and WAS ND Node charms |
-| [jenkins-workspace](https://github.com/juju-solutions/layer-jenkins-workspace) | Jenkins Workspace | Configure Jenkins with workspace snapshots |
-| [jenkins](https://github.com/jenkinsci/jenkins-charm.git) | jenkins | Juju charm to deploy and scale Jenkins  |
-| [juju-client](https://github.com/tengu-team/layer-juju-client.git) | juju-client | Layer for Charms which depend on Juju CLI being installed in active Model  |
-| [kubernetes-common](https://github.com/juju-solutions/kubernetes.git) | Kubernetes common lib | Provides a common library for Kubernetes charms. |
-| [layer-debug](https://github.com/charms/layer-debug.git) | debug | Provides a troubleshooting debug action |
-| [leadership](https://git.launchpad.net/layer-leadership) | Leadership layer | Help reactive framework charms deal with Juju leadership |
-| [lets-encrypt](https://github.com/cmars/layer-lets-encrypt) | lets-encrypt | Automatic Let's Encrypt registration for Juju charms, just set the fqdn |
-| [lxd-proxy](https://github.com/omnivector-solutions/layer-lxd-proxy) | LXD Proxy | iptables proxy that adds and removes PREROUTING rules to ease host -> container proxying with juju |
-| [memcache-client](https://github.com/omnivector-solutions/layer-memcache-client) | Memcache Client | Client layer for Memcache |
-| [metrics](https://github.com/CanonicalLtd/layer-metrics) | Metrics Layer | Reactive charm layer supporting Juju metrics collection |
-| [munge](https://github.com/omnivector-solutions/layer-munge) | munge | Reactive layer for Munge authentication service. |
-| [munin](https://github.com/freyes/layer-munin) | munin | munin server |
-| [nagios](https://git.launchpad.net/nagios-layer) | Nagios Layer | Provide boilerplate required to relate services to the cs:nrpe subordinate |
-| [nginx-passenger](https://github.com/omnivector-solutions/layer-nginx-passenger) | Nginx Passenger | Reactive layer for nginx-passenger |
-| [nginx](https://github.com/battlemidget/juju-layer-nginx.git) | NGINX | NGINX layer for deploying web applications |
-| [nodejs](https://github.com/battlemidget/juju-layer-node.git) | NodeJS | Runtime layer for NodeJS applications |
-| [ntpmon](https://git.launchpad.net/ntpmon) | ntpmon | NTP monitoring for telegraf |
-| [nvidia-cuda](https://github.com/juju-solutions/layer-nvidia-cuda) | Nvidia CUDA | Installs CUDA and Nvidia drivers when supported GPU hardware is detected |
-| [openjdk](https://github.com/juju-solutions/layer-openjdk.git) | OpenJDK | OpenJDK using the java layer |
-| [openstack-api](https://github.com/openstack/charm-layer-openstack-api) | OpenStack API layer | OpenStack API layer |
-| [openstack-principle](https://github.com/openstack/charm-layer-openstack-principle) | OpenStack principle layer | OpenStack principle layer |
-| [openstack](https://github.com/openstack/charm-layer-openstack) | OpenStack base layer | OpenStack base layer |
-| [options](https://github.com/juju-solutions/layer-options.git) | options | Layer for reading options defined in layer.yaml |
-| [promreg-client](https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/layer-promreg-client) | promreg-client | A layer to aid in registering a target with Prometheus Registration |
-| [puppet-agent](https://github.com/omnivector-solutions/layer-puppet-agent.git) | Puppet Agent | Puppet-agent layer - supports puppet 3 & 4. |
-| [puppet](https://github.com/juju-solutions/layer-puppet.git) | Puppet Layer (deprecated) | Puppet layer (deprecated; use puppet-agent) |
-| [ruby](https://github.com/battlemidget/juju-layer-ruby.git) | Ruby | Build layer for Ruby applications |
-| [slurm](https://github.com/omnivector-solutions/layer-slurm) | slurm | Base layer for Slurm |
-| [snap-action](https://github.com/lutostag/layer-snap-action.git) | snap-action | Perform snap commands via an action |
-| [snap](https://git.launchpad.net/layer-snap) | Snap layer | Snap layer for installing and updating Snap packages |
-| [sshproxy](https://github.com/AdamIsrael/layer-sshproxy) | sshproxy | A layer intended to ease the development of charms that need to execute commands over SSH. |
-| [status](https://github.com/juju-solutions/layer-status) | Status management layer | Manage workload status in reactive charms |
-| [storage](https://github.com/juju-solutions/layer-storage) | Storage | A charm layer to handle Juju attached storage devices. |
-| [supervisor](https://github.com/omnivector-solutions/layer-supervisor) | Supervisor | Layer for Supervisor |
-| [swarm](https://github.com/chuckbutler/layer-swarm.git) | Docker Swarm | Stand alone layer, to extend docker into a Swarm cluster participant |
-| [tls-client](https://github.com/juju-solutions/layer-tls-client.git) | tls-client | A layer to handle interface:tls-certificates requires side. |
-| [tls](https://github.com/juju-solutions/layer-tls) | tls | The tls charm layer creates certificates and keys for each peer unit of a charm. |
-| [uwsgi](https://github.com/marcoceppi/layer-uwsgi) | uWSGI | uWSGI layer |
-| [vault-kv](https://github.com/juju-solutions/layer-vault-kv) | Vault KV layer | Layer for using Vault as a secure KV store |
-| [vaultlocker](https://github.com/juju-solutions/layer-vaultlocker) | VaultLocker layer | Layer for managing secure disk storage locations using VaultLocker |
-| [vnfproxy](https://github.com/AdamIsrael/vnfproxy.git) | vnfproxy | A layer to ease development of "proxy" charms that operate against VNF images |
+| ID | Repo | Docs | Name | Summary |
+| --- | --- | --- | --- | --- |
+| ansible-base | [Repo](https://github.com/chuckbutler/ansible-base) | [Docs](https://github.com/chuckbutler/ansible-base#readme) | ansible-base | Base / charm layer for charming w/ Ansible |
+| apache-bigtop-base | [Repo](https://github.com/juju-solutions/layer-apache-bigtop-base.git) | [Docs](https://github.com/juju-solutions/layer-apache-bigtop-base.git#readme) | Apache Bigtop Base Layer | Base layer for charms needing Apache Bigtop  |
+| apache-bigtop-gateway | [Repo](https://github.com/juju-solutions/layer-apache-bigtop-gateway) | [Docs](https://github.com/juju-solutions/layer-apache-bigtop-gateway#readme) | apache-bigtop-gateway | Base layer for Gateway node from Apache Big Top |
+| apache-flume-base | [Repo](https://github.com/juju-solutions/layer-apache-flume-base.git) | [Docs](https://github.com/juju-solutions/layer-apache-flume-base.git#readme) | Apache Flume Base | Base layer for Apache Flume charms |
+| apache-hadoop-datanode | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-datanode.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-datanode.git#readme) | Apache Hadoop DataNode | Base / charm layer for the DataNode component of Hadoop |
+| apache-hadoop-namenode | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-namenode.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-namenode.git#readme) | Apache Hadoop NameNode | Charm layer for the NameNode component of Hadoop |
+| apache-hadoop-nodemanager | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-nodemanager.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-nodemanager.git#readme) | Apache Hadoop NodeManager | Base / charm layer for the NodeManager component of Hadoop |
+| apache-hadoop-plugin | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-plugin.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-plugin.git#readme) | apache-hadoop-plugin | Simplified connection point for Apache Hadoop platform |
+| apache-hadoop-resourcemanager | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-resourcemanager.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-resourcemanager.git#readme) | Apache Hadoop ResourceManager | Charm layer for the ResourceManager component of Hadoop |
+| apache-hadoop-slave | [Repo](https://github.com/juju-solutions/layer-apache-hadoop-slave.git) | [Docs](https://github.com/juju-solutions/layer-apache-hadoop-slave.git#readme) | apache-hadoop-slave | Combined slave node (DataNode + NodeManager) for Apache Hadoop |
+| apache-php | [Repo](https://github.com/juju-solutions/layer-apache-php.git) | [Docs](https://github.com/juju-solutions/layer-apache-php.git#readme) | Apache PHP base layer | Configurable base for Apache PHP charms |
+| apache-wsgi | [Repo](https://git.launchpad.net/~jacekn/charms/+source/apache-wsgi) | [Docs](https://git.launchpad.net/~jacekn/charms/+source/tree/README.md) | Apache WSGI base layer | Configurable base for Apache WSGI charms |
+| apt | [Repo](https://git.launchpad.net/layer-apt) | [Docs](https://github.com/stub42/layer-apt#readme) | Apt layer | Easily deal with apt sources and deb packages |
+| barbican-client | [Repo](https://github.com/omnivector-solutions/layer-barbican-client) | [Docs](https://github.com/omnivector-solutions/layer-barbican-client#readme) | Barbican Client | Reactive layer to help pull secrets from barbican |
+| basic | [Repo](https://github.com/juju-solutions/layer-basic.git) | [Docs](https://github.com/juju-solutions/layer-basic.git#readme) | Basic Layer | Base layer for charms with the Reactive framework |
+| beats-base | [Repo](https://github.com/juju-solutions/layer-beats-base) | [Docs](https://github.com/juju-solutions/layer-beats-base#readme) | Beats Base | Base layer for Elastic Beats |
+| bigtop-base | [Repo](https://github.com/juju-solutions/layer-apache-bigtop-base.git) | [Docs](https://github.com/juju-solutions/layer-apache-bigtop-base.git#readme) | Apache Bigtop Base Layer | Base layer for charms needing Apache Bigtop  |
+| buildpacks | [Repo](https://git.launchpad.net/~bcsaller/charms/+source/buildpacks) | [Docs](https://git.launchpad.net/~bcsaller/charms/+source/tree/README.md) | Buildpacks | Experimental layer for using buildpacks to generate Charmed applications |
+| caas-base | [Repo](https://github.com/juju-solutions/layer-caas-base.git) | [Docs](https://github.com/juju-solutions/layer-caas-base.git#readme) | Base Layer for CAAS charms | Base layer for CAAS charms with the Reactive framework |
+| cdk-service-kicker | [Repo](https://github.com/juju-solutions/layer-cdk-service-kicker.git) | [Docs](https://github.com/juju-solutions/layer-cdk-service-kicker.git#readme) | CDK Service Kicker | Installs a background service, cdk-service-kicker, for kicking cdk services. |
+| ceph-base | [Repo](https://github.com/ChrisMacNaughton/layer-ceph-base) | [Docs](https://github.com/ChrisMacNaughton/layer-ceph-base#readme) | EXPERIMENTAL Ceph Base Layer | EXPERIMENTAL Ceph base layer |
+| ceph-basic | [Repo](https://github.com/ChrisMacNaughton/layer-ceph-basic) | [Docs](https://github.com/ChrisMacNaughton/layer-ceph-basic#readme) | EXPERIMENTAL ceph-basic | EXPERIMENTAL ceph-basic layer |
+| ceph-mon | [Repo](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon) | [Docs](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon#readme) | EXPERIMENTAL Ceph Mon layer | EXPERIMENTAL Ceph Mon layer |
+| charmscaler-base | [Repo](https://github.com/elastisys/layer-charmscaler-base) | [Docs](https://github.com/elastisys/layer-charmscaler-base#readme) | Charmscaler Base | Charmscaler base layer |
+| conda-api | [Repo](https://github.com/omnivector-solutions/layer-conda-api) | [Docs](https://github.com/omnivector-solutions/layer-conda-api#readme) | Conda API | Conda API layer |
+| consul-base | [Repo](https://github.com/omnivector-solutions/layer-consul-base) | [Docs](https://github.com/omnivector-solutions/layer-consul-base#readme) | Consul Base | Reactive base layer for consul |
+| coordinator | [Repo](https://git.launchpad.net/layer-coordinator ) | [Docs](https://git.launchpad.net/tree/README.md) | Coordinator Layer | Coordinate operations between units in a service, such as rolling restarts. |
+| debug | [Repo](https://github.com/juju-solutions/layer-debug.git) | [Docs](https://github.com/juju-solutions/layer-debug.git#readme) | debug | Provides a troubleshooting debug action |
+| django | [Repo](https://github.com/marcoceppi/layer-django.git) | [Docs](https://github.com/marcoceppi/layer-django.git#readme) | Django | Django / GUNICORN |
+| docker-resource | [Repo](https://github.com/juju-solutions/layer-docker-resource.git) | [Docs](https://github.com/juju-solutions/layer-docker-resource.git#readme) | Docker Resource Layer | Layer for managing charm resources of type 'docker' |
+| docker | [Repo](https://github.com/juju-solutions/layer-docker.git) | [Docs](https://github.com/juju-solutions/layer-docker.git#readme) | Docker | Layer to deliver and install Docker on Ubuntu, Debian, Centos hosts. |
+| elastic-base | [Repo](https://github.com/omnivector-solutions/layer-elastic-base.git) | [Docs](https://github.com/omnivector-solutions/layer-elastic-base.git#readme) | Elastic-Base | Base layer for Elastic.co charms |
+| elasticsearch-client | [Repo](https://github.com/omnivector-solutions/layer-elasticsearch-client) | [Docs](https://github.com/omnivector-solutions/layer-elasticsearch-client#readme) | Elasticsearch Client | Elasticsearch client layer |
+| elixir | [Repo](https://github.com/battlemidget/juju-layer-elixir.git) | [Docs](https://github.com/battlemidget/juju-layer-elixir.git#readme) | Elixir | Runtime layer for Elixir applications |
+| flannel | [Repo](https://github.com/juju-solutions/layer-flannel) | [Docs](https://github.com/juju-solutions/layer-flannel#readme) | Flannel | Flannel Overlay Network layer for docker |
+| flask | [Repo](https://github.com/tengu-team/layer-flask) | [Docs](https://github.com/tengu-team/layer-flask#readme) | Flask | Layer to create Flask webservers running on nginx |
+| git-deploy | [Repo](https://github.com/omnivector-solutions/layer-git-deploy.git) | [Docs](https://github.com/omnivector-solutions/layer-git-deploy.git#readme) | Git Deploy | Layer to aid with deploying code from github |
+| go-binary | [Repo](https://github.com/cloud-green/go-binary-layer) | [Docs](https://github.com/cloud-green/go-binary-layer#readme) | Go Binary Base Layer | Takes a statically compiled go binary and starts it as a service |
+| hadoop-base | [Repo](https://github.com/juju-solutions/layer-hadoop-base.git) | [Docs](https://github.com/juju-solutions/layer-hadoop-base.git#readme) | Hadoop Base | Base layer for a charm needing the Apache Hadoop libraries |
+| hadoop-client | [Repo](https://github.com/juju-solutions/layer-hadoop-client.git) | [Docs](https://github.com/juju-solutions/layer-hadoop-client.git#readme) | hadoop-client | Base and charm layer for Hadoop clients |
+| hadoop-datanode | [Repo](https://github.com/juju-solutions/layer-hadoop-datanode) | [Docs](https://github.com/juju-solutions/layer-hadoop-datanode#readme) | hadoop-datanode | Base layer for DataNode from Apache BigTop |
+| hadoop-ganglia | [Repo](https://github.com/juju-solutions/layer-hadoop-ganglia.git) | [Docs](https://github.com/juju-solutions/layer-hadoop-ganglia.git#readme) | hadoop-ganglia | Base layer for adding Ganglia support to Hadoop core charms |
+| hadoop-nodemanager | [Repo](https://github.com/juju-solutions/layer-hadoop-nodemanager) | [Docs](https://github.com/juju-solutions/layer-hadoop-nodemanager#readme) | hadoop-nodemanager | Base layer for NodeManager from Apache BigTop |
+| haproxy-core | [Repo](https://github.com/juju-solutions/layer-haproxy-core.git) | [Docs](https://github.com/juju-solutions/layer-haproxy-core.git#readme) | haproxy-core | A reactive layer that delivers a minimal haproxy layer to use in other application layers. |
+| hhvm | [Repo](https://github.com/battlemidget/juju-layer-hhvm) | [Docs](https://github.com/battlemidget/juju-layer-hhvm#readme) | HHVM | Provides HHVM and composer for php applications |
+| ibm-base | [Repo](https://code.launchpad.net/~ibmcharmers/layer-ibm-base/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/layer-ibm-base/files/README.md) | IBM Base Layer | Base layer for IBM charms |
+| ibm-im | [Repo](http://launchpad.net/~ibmcharmers/ibmlayers/layer-ibm-im) | [Docs](http://bazaar.launchpad.net/~ibmcharmers/ibmlayers/files/README.md) | IBM IM | This layer provides IBM Installation Manager, which can be used to install many IBM products. |
+| ibm-was-nd | [Repo](https://code.launchpad.net/~ibmcharmers/charms/trusty/layer-ibm-was-nd/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/charms/trusty/layer-ibm-was-nd/files/README.md) | IBM WAS ND | Charm layer for IBM WAS ND DM and WAS ND Node charms |
+| jenkins-workspace | [Repo](https://github.com/juju-solutions/layer-jenkins-workspace) | [Docs](https://github.com/juju-solutions/layer-jenkins-workspace#readme) | Jenkins Workspace | Configure Jenkins with workspace snapshots |
+| jenkins | [Repo](https://github.com/jenkinsci/jenkins-charm.git) | [Docs](https://github.com/jenkinsci/jenkins-charm.git#readme) | jenkins | Juju charm to deploy and scale Jenkins  |
+| juju-client | [Repo](https://github.com/tengu-team/layer-juju-client.git) | [Docs](https://github.com/tengu-team/layer-juju-client.git#readme) | juju-client | Layer for Charms which depend on Juju CLI being installed in active Model  |
+| kubernetes-common | [Repo](https://github.com/juju-solutions/kubernetes.git) | [Docs](https://github.com/juju-solutions/kubernetes.git#readme) | Kubernetes common lib | Provides a common library for Kubernetes charms. |
+| layer-debug | [Repo](https://github.com/charms/layer-debug.git) | [Docs](https://github.com/charms/layer-debug.git#readme) | debug | Provides a troubleshooting debug action |
+| leadership | [Repo](https://git.launchpad.net/layer-leadership) | [Docs](https://git.launchpad.net/tree/README.md) | Leadership layer | Help reactive framework charms deal with Juju leadership |
+| lets-encrypt | [Repo](https://github.com/cmars/layer-lets-encrypt) | [Docs](https://github.com/cmars/layer-lets-encrypt#readme) | lets-encrypt | Automatic Let's Encrypt registration for Juju charms, just set the fqdn |
+| lxd-proxy | [Repo](https://github.com/omnivector-solutions/layer-lxd-proxy) | [Docs](https://github.com/omnivector-solutions/layer-lxd-proxy#readme) | LXD Proxy | iptables proxy that adds and removes PREROUTING rules to ease host -> container proxying with juju |
+| memcache-client | [Repo](https://github.com/omnivector-solutions/layer-memcache-client) | [Docs](https://github.com/omnivector-solutions/layer-memcache-client#readme) | Memcache Client | Client layer for Memcache |
+| metrics | [Repo](https://github.com/CanonicalLtd/layer-metrics) | [Docs](https://github.com/CanonicalLtd/layer-metrics#readme) | Metrics Layer | Reactive charm layer supporting Juju metrics collection |
+| munge | [Repo](https://github.com/omnivector-solutions/layer-munge) | [Docs](https://github.com/omnivector-solutions/layer-munge#readme) | munge | Reactive layer for Munge authentication service. |
+| munin | [Repo](https://github.com/freyes/layer-munin) | [Docs](https://github.com/freyes/layer-munin#readme) | munin | munin server |
+| nagios | [Repo](https://git.launchpad.net/nagios-layer) | [Docs](https://git.launchpad.net/tree/README.md) | Nagios Layer | Provide boilerplate required to relate services to the cs:nrpe subordinate |
+| nginx-passenger | [Repo](https://github.com/omnivector-solutions/layer-nginx-passenger) | [Docs](https://github.com/omnivector-solutions/layer-nginx-passenger#readme) | Nginx Passenger | Reactive layer for nginx-passenger |
+| nginx | [Repo](https://github.com/battlemidget/juju-layer-nginx.git) | [Docs](https://github.com/battlemidget/juju-layer-nginx.git#readme) | NGINX | NGINX layer for deploying web applications |
+| nodejs | [Repo](https://github.com/battlemidget/juju-layer-node.git) | [Docs](https://github.com/battlemidget/juju-layer-node.git#readme) | NodeJS | Runtime layer for NodeJS applications |
+| ntpmon | [Repo](https://git.launchpad.net/ntpmon) | [Docs](https://git.launchpad.net/tree/README.md) | ntpmon | NTP monitoring for telegraf |
+| nvidia-cuda | [Repo](https://github.com/juju-solutions/layer-nvidia-cuda) | [Docs](https://github.com/juju-solutions/layer-nvidia-cuda#readme) | Nvidia CUDA | Installs CUDA and Nvidia drivers when supported GPU hardware is detected |
+| openjdk | [Repo](https://github.com/juju-solutions/layer-openjdk.git) | [Docs](https://github.com/juju-solutions/layer-openjdk.git#readme) | OpenJDK | OpenJDK using the java layer |
+| openstack-api | [Repo](https://github.com/openstack/charm-layer-openstack-api) | [Docs](https://github.com/openstack/charm-layer-openstack-api#readme) | OpenStack API layer | OpenStack API layer |
+| openstack-principle | [Repo](https://github.com/openstack/charm-layer-openstack-principle) | [Docs](https://github.com/openstack/charm-layer-openstack-principle#readme) | OpenStack principle layer | OpenStack principle layer |
+| openstack | [Repo](https://github.com/openstack/charm-layer-openstack) | [Docs](https://github.com/openstack/charm-layer-openstack#readme) | OpenStack base layer | OpenStack base layer |
+| options | [Repo](https://github.com/juju-solutions/layer-options.git) | [Docs](https://github.com/juju-solutions/layer-options.git#readme) | options | Layer for reading options defined in layer.yaml |
+| promreg-client | [Repo](https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/layer-promreg-client) | [Docs](https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/tree/README.md) | promreg-client | A layer to aid in registering a target with Prometheus Registration |
+| puppet-agent | [Repo](https://github.com/omnivector-solutions/layer-puppet-agent.git) | [Docs](https://github.com/omnivector-solutions/layer-puppet-agent.git#readme) | Puppet Agent | Puppet-agent layer - supports puppet 3 & 4. |
+| puppet | [Repo](https://github.com/juju-solutions/layer-puppet.git) | [Docs](https://github.com/juju-solutions/layer-puppet.git#readme) | Puppet Layer (deprecated) | Puppet layer (deprecated; use puppet-agent) |
+| ruby | [Repo](https://github.com/battlemidget/juju-layer-ruby.git) | [Docs](https://github.com/battlemidget/juju-layer-ruby.git#readme) | Ruby | Build layer for Ruby applications |
+| slurm | [Repo](https://github.com/omnivector-solutions/layer-slurm) | [Docs](https://github.com/omnivector-solutions/layer-slurm#readme) | slurm | Base layer for Slurm |
+| snap-action | [Repo](https://github.com/lutostag/layer-snap-action.git) | [Docs](https://github.com/lutostag/layer-snap-action.git#readme) | snap-action | Perform snap commands via an action |
+| snap | [Repo](https://git.launchpad.net/layer-snap) | [Docs](https://git.launchpad.net/tree/README.md) | Snap layer | Snap layer for installing and updating Snap packages |
+| sshproxy | [Repo](https://github.com/AdamIsrael/layer-sshproxy) | [Docs](https://github.com/AdamIsrael/layer-sshproxy#readme) | sshproxy | A layer intended to ease the development of charms that need to execute commands over SSH. |
+| status | [Repo](https://github.com/juju-solutions/layer-status) | [Docs](https://github.com/juju-solutions/layer-status#readme) | Status management layer | Manage workload status in reactive charms |
+| storage | [Repo](https://github.com/juju-solutions/layer-storage) | [Docs](https://github.com/juju-solutions/layer-storage#readme) | Storage | A charm layer to handle Juju attached storage devices. |
+| supervisor | [Repo](https://github.com/omnivector-solutions/layer-supervisor) | [Docs](https://github.com/omnivector-solutions/layer-supervisor#readme) | Supervisor | Layer for Supervisor |
+| swarm | [Repo](https://github.com/chuckbutler/layer-swarm.git) | [Docs](https://github.com/chuckbutler/layer-swarm.git#readme) | Docker Swarm | Stand alone layer, to extend docker into a Swarm cluster participant |
+| tls-client | [Repo](https://github.com/juju-solutions/layer-tls-client.git) | [Docs](https://github.com/juju-solutions/layer-tls-client.git#readme) | tls-client | A layer to handle interface:tls-certificates requires side. |
+| tls | [Repo](https://github.com/juju-solutions/layer-tls) | [Docs](https://github.com/juju-solutions/layer-tls#readme) | tls | The tls charm layer creates certificates and keys for each peer unit of a charm. |
+| uwsgi | [Repo](https://github.com/marcoceppi/layer-uwsgi) | [Docs](https://github.com/marcoceppi/layer-uwsgi#readme) | uWSGI | uWSGI layer |
+| vault-kv | [Repo](https://github.com/juju-solutions/layer-vault-kv) | [Docs](https://github.com/juju-solutions/layer-vault-kv#readme) | Vault KV layer | Layer for using Vault as a secure KV store |
+| vaultlocker | [Repo](https://github.com/juju-solutions/layer-vaultlocker) | [Docs](https://github.com/juju-solutions/layer-vaultlocker#readme) | VaultLocker layer | Layer for managing secure disk storage locations using VaultLocker |
+| vnfproxy | [Repo](https://github.com/AdamIsrael/vnfproxy.git) | [Docs](https://github.com/AdamIsrael/vnfproxy.git#readme) | vnfproxy | A layer to ease development of "proxy" charms that operate against VNF images |
 
 <!-- /list-of-layers -->
 
@@ -137,158 +141,158 @@ List of Interface Layers
 
 <!-- list-of-interfaces -->
 
-| ID | Name | Summary |
-| --- | --- | --- |
-| [apache-website](https://github.com/juju-solutions/interface-apache-website.git) | apache-website | Interface layer for the apache-website interface protocol |
-| [arangodb](https://github.com/tengu-team/interface-arangodb.git) | arangodb | Interface layer for ArangoDB |
-| [audit](https://launchpad.net/~timkuhlman/charm-layer-auditd/audit-interface) | audit | Interface for use with the auditd charm |
-| [aws-elb](https://github.com/omnivector-solutions/interface-aws-elb) | AWS-ELB | AWS-ELB provides and requires interfaces. |
-| [aws-integration](https://github.com/juju-solutions/interface-aws-integration.git) | aws-integration | Interface layer for connecting to the AWS integration charm |
-| [azure-integration](https://github.com/juju-solutions/interface-azure-integration.git) | azure-integration | Interface layer for connecting to the Azure integration charm |
-| [barbican-hsm](https://github.com/openstack/charm-interface-barbican-hsm) | barbican-hsm | Interface supporting the integration between Barbican and HSM devices |
-| [barbican-secrets](https://github.com/openstack-charmers/charm-interface-barbican-secrets.git) | barbican-secrets | Interface supporting the integration between Barbican and secrets storage plugins |
-| [basic-auth-check](https://github.com/CanonicalLtd/juju-interface-basic-auth-check) | basic-auth-check | Interface for the basic-auth-service to validate HTTP Basic-Auth credentials |
-| [benchmark](https://github.com/juju-solutions/interface-benchmark.git) | benchmark | Interface layer for the benchmark protocol |
-| [bgp](https://github.com/openstack/charm-interface-bgp.git) | bgp | Interface layer for exchanging BGP neighbour information between charms |
-| [bind-rndc](https://github.com/openstack/charm-interface-bind-rndc) | BIND RNDC interface | BIND RNDC interface |
-| [cassandra](https://git.launchpad.net/interface-cassandra) | cassandra | Cassandra database client interface |
-| [ceph-admin](https://github.com/cholcombe973/juju-interface-ceph-admin) | ceph-admin | The admin interface for ceph will provide the user with the ceph admin key |
-| [ceph-base](https://github.com/openstack/charm-layer-ceph-base) | Ceph Base Layer | Ceph base layer |
-| [ceph-client](https://github.com/openstack-charmers/charm-interface-ceph-client) | ceph-client | Ceph Client interface |
-| [ceph-mds](https://github.com/openstack/charm-interface-ceph-mds) | ceph-mds | CephFS interface to the MDS relation on ceph-mon |
-| [ceph-osd](https://github.com/ChrisMacNaughton/juju-interface-ceph-osd) | ceph-osd | ceph osd relation |
-| [ceph-radosgw](https://github.com/ChrisMacNaughton/juju-interface-ceph-radosgw) | ceph-radosgw | Ceph RadosGW interface |
-| [ceph](https://github.com/ChrisMacNaughton/juju-interface-ceph) | ceph | ceph mon peer interface |
-| [charms-ci](https://github.com/juju-solutions/interface-charms-ci.git) | charms-ci | Juju charms CI interface |
-| [conda](https://github.com/omnivector-solutions/interface-conda) | Conda | Conda provides and requires interfaces |
-| [conn-check](https://git.launchpad.net/~ubuntuone-hackers/conn-check/+git/interface-conn-check) | conn-check | conn-check interface |
-| [consul-agent](https://github.com/ChrisMacNaughton/juju-interface-consul.git) | consul-agent | Hashicorp Consul |
-| [consul](https://github.com/juju-solutions/interface-consul) | consul | Hashicorp Consul |
-| [cwr-ci](https://github.com/juju-solutions/interface-cwr-ci.git) | cwr-ci | Interface for relating to Cloud Weather Report (part of the Juju CI system) |
-| [dashboard-plugin](https://github.com/openstack/charm-interface-dashboard-plugin.git) | dashboard-plugin | This interface is for use with OpenStack Dashboard plugin subordinate charms |
-| [db-info](https://github.com/omnivector-solutions/interface-db-info) | DB Info | Ease the process of application <-> application database creds transference. |
-| [db2](https://launchpad.net/~ibmcharmers/interface-ibm-db2/trunk) | db2 | This interface layer handles the communication between  IBM DB2 and Consumer charms. |
-| [dbname](https://github.com/omnivector-solutions/interface-dbname.git) | DB Name | Interface to coordinate database name between applications. |
-| [designate](https://github.com/openstack-charmers/charm-interface-designate) | designate | Designate DNS as a Service interface |
-| [dfs-slave](https://github.com/juju-solutions/interface-dfs-slave.git) | dfs-slave | Interface layer for the DataNode <-> NameNode protocol |
-| [dfs](https://github.com/juju-solutions/interface-dfs.git) | dfs | Interface layer for the hdfs interface protocol |
-| [dm-node](https://code.launchpad.net/~ibmcharmers/interface-ibm-dm-node/trunk) | dm-node | This interface handles the comunication between IBM WAS ND DM and IBM WAS ND Node charms |
-| [docker-image-host](https://github.com/tengu-team/interface-docker-image-host) | docker-image-host | Interface to send image to docker host |
-| [docker-registry](https://github.com/juju-solutions/interface-docker-registry.git) | docker-registry | Interface layer for connecting to the Docker Registry charm |
-| [dockerhost](https://github.com/juju-solutions/interface-dockerhost) | dockerhost | Docker connection information for a unit |
-| [druid-config](https://gitlab.com/spiculedata/juju/druid-config-relation.git) | Druid Configuration | Configuration layer for Spicule's Druid charms. |
-| [elastic-beats](https://github.com/juju-solutions/interface-elastic-beats) | elastic-beats | Interface for elastic beats |
-| [elasticsearch](http://github.com/juju-solutions/interface-elasticsearch ) | elasticsearch | Interface to connect with elasticsearch. |
-| [etcd-proxy](https://github.com/juju-solutions/interface-etcd-proxy) | etcd-proxy | Do you need etcd as a read/readwrite proxy to a cluster? use this interface. |
-| [etcd](https://github.com/juju-solutions/interface-etcd) | etcd | Interface for relating to etcd |
-| [flume-agent](https://github.com/juju-solutions/interface-flume-agent.git) | flume-agent | Interface layer for communication between Apache Flume charms |
-| [gcp-integration](https://github.com/juju-solutions/interface-gcp-integration.git) | gcp-integration | Interface layer for connecting to the GCP integration charm |
-| [generic-ip-port-user-pass](https://git.launchpad.net/generic-ip-port-user-pass-charm-interface) | generic-ip-port-user-pass | An interface for reactive charms needing to pass generic IP (or URL), port, username and password data |
-| [giraph](https://github.com/juju-solutions/interface-giraph) | giraph | This interface handles the communication between Apache Giraph and its clients |
-| [gluster-fuse](https://github.com/cholcombe973/juju-interface-gluster-fuse) | gluster-fuse | Distributed posix storage provided by GlusterFS |
-| [gluster-nfs](https://github.com/cholcombe973/juju-interface-gluster-client) | gluster-nfs | Scale out NFS provided by GlusterFS |
-| [gluster-peer](https://github.com/wolsen/charm-interface-gluster-peer) | gluster-peer | Peer interface for glusterfs nodes |
-| [gnocchi](https://github.com/openstack-charmers/charm-interface-gnocchi) | gnocchi | Gnocchi Metrics Service interface |
-| [gpfs](https://code.launchpad.net/~ibmcharmers/interface-ibm-gpfs/trunk) | gpfs | Interface layer between IBM Spectrum Scale Manager and IBM Spectrum Scale client as well as peer communication among manager/client units |
-| [grafana-source](https://git.launchpad.net/interface-grafana-source) | grafana-source | Grafana source |
-| [hacluster](https://github.com/openstack/charm-interface-hacluster.git) | hacluster | hacluster interface for relations with hacluster subordinate charm |
-| [hadoop-plugin](https://github.com/juju-solutions/interface-hadoop-plugin.git) | hadoop-plugin | Interface for relating to Apache Hadoop |
-| [hadoop-rest](https://github.com/juju-solutions/interface-hadoop-rest) | hadoop-rest | Interface layer for connecting to hadoop-plugin without installation |
-| [hbase-quorum](https://github.com/juju-solutions/interface-hbase-quorum.git) | hbase quorum | This interface layer handles the communication among Apache HBase peers |
-| [hbase](https://github.com/juju-solutions/interface-hbase.git) | hbase | This interface layer handles the communication between Apache HBase and its clients |
-| [hive](https://github.com/juju-solutions/interface-hive.git) | hive | Interface for relating to Apache Hive |
-| [http](https://github.com/juju-solutions/interface-http.git) | http | HTTP Relation Stub |
-| [https](https://code.launchpad.net/~ibmcharmers/interface-https/trunk) | https |  Basic HTTPS interface |
-| [ibm-db2](https://launchpad.net/~ibmcharmers/interface-ibm-db2/trunk) | ibm-db2 | This interface layer handles the communication between  IBM DB2 and Consumer charms. |
-| [ibm-mq](https://code.launchpad.net/~ibmcharmers/interface-ibm-mq/trunk) | ibm-mq | This interface handles the communication between IBM MQ and other consumer charms. |
-| [ibm-wxs](https://launchpad.net/~ibmcharmers/interface-ibm-wxs/trunk) | ibm-wxs | This interface layer handles the communication between  IBM WXS Catalog charm and other consumer charms, such as IBM WXS Container and IBM WXS Client |
-| [ignite-hadoop](https://github.com/juju-solutions/interface-ignite-hadoop) | ignite-hadoop | Minimal interface layer for connecting Apache Ignite-Hadoop to Apache Hadoop slave |
-| [influxdb-api](https://github.com/ChrisMacNaughton/interface-influxdb-api.git) | influxdb-api | InfluxDB Query Interface |
-| [java](https://github.com/juju-solutions/interface-java.git) | java | Interface for relating to subordinate charms providing a Java runtime or JDK |
-| [jdbc](https://gitlab.com/spiculedata/juju/jdbc-interface.git) | jdbc | JDBC interface for generic connectivity across databases |
-| [jenkins-extension](https://github.com/juju-solutions/interface-jenkins-extension.git) | jenkins-extension | Admin interface to the jenkins master |
-| [jenkins-slave](https://github.com/freeekanayaka/interface-jenkins-slave.git) | jenkins-slave | Communication between a Jenkins master and a Jenkins slave |
-| [jenkins-zuul](https://github.com/freeekanayaka/interface-jenkins-zuul.git) | jenkins-zuul | communication between a Jenkins master and Zuul Jenkins via the zuul interface |
-| [juju-info](https://github.com/juju-solutions/interface-juju-info.git) | juju-info | Implied interface for subordinates with special behavior. This is not a substitute for a proper relationship interface.  |
-| [kafka](https://github.com/juju-solutions/interface-kafka.git) | kafka | Interface layer for communication between Kafka and its clients |
-| [kapacitor](https://github.com/tengu-team/interface-kapacitor.git) | kapacitor | Interface layer for Kapacitor |
-| [keystone-admin](https://github.com/openstack/charm-interface-keystone-admin) | keystone-admin | keystone-admin:identity-admin interface to use shared admin API credentials |
-| [keystone-credentials](https://github.com/openstack/charm-interface-keystone-credentials) | keystone-credentials | keystone-credentials: Interface for integrating with Keystone identity credentials |
-| [keystone-domain-backend](https://github.com/openstack-charmers/charm-interface-keystone-domain-backend) | keystone-domain-backend | Interface for integration of subordinate charms providing domain specific identity backends |
-| [keystone-fid-service-provider](https://github.com/dshcherb/charm-interface-keystone-fid-service-provider) | keystone-fid-service-provider | An interface to connect a federated identity provider to the Keystone charm |
-| [keystone](https://github.com/openstack/charm-interface-keystone) | keystone | Keystone interface |
-| [kube-control](https://github.com/juju-solutions/interface-kube-control.git) | kube-control | master-worker control interface for Kubernetes |
-| [kube-dns](https://github.com/juju-solutions/interface-kube-dns.git) | kube-dns | Kubernetes DNS Details |
-| [kubernetes-cni](https://github.com/juju-solutions/interface-kubernetes-cni) | kubernetes-cni | Interface for relating various CNI implementations |
-| [limeds](https://github.com/tengu-team/interface-limeds) | limeds | Interface to connect to LimeDS |
-| [livy](https://gitlab.com/spiculedata/juju/livy-relation.git) | Apache Livy relation | Relation to connect a charm to Apache Livy. |
-| [local-monitors](https://github.com/cmars/local-monitors-interface) | local-monitors | relation for registering nagios checks |
-| [logstash-client](https://github.com/juju-solutions/interface-logstash-client) | logstash-client | Interface for connecting with logstash based systems. |
-| [mahout](https://github.com/juju-solutions/interface-mahout) | mahout | This interface layer handles the communication between Apache Mahout and its clients |
-| [manila-plugin](https://github.com/openstack/charm-interface-manila-plugin) | manila-plugin | manila-plugin: configuration plugin to allow manila plugins to configure the manila service |
-| [mapred-slave](https://github.com/juju-solutions/interface-mapred-slave.git) | mapred-slave | Interface layer for the NodeManager <-> ResourceManager protocol |
-| [mapred](https://github.com/juju-solutions/interface-mapred.git) | mapred | Interface for the YARN client protocol |
-| [memcache](https://github.com/omnivector-solutions/interface-memcache.git) | Memcache | Interface for relating memcache. |
-| [midonet-api](https://github.com/celebdor/interface-midonet-api.git) | MidoNet API | MidoNet API interface between provider and consuming charms |
-| [mongodb-cluster](https://github.com/tkuhlman/juju-relation-mongodb) | mongodb-cluster | relation to connect to a mongo database cluster |
-| [mongodb](https://github.com/cloud-green/juju-relation-mongodb) | mongodb | relation to connect to a mongo database |
-| [monitor](https://github.com/juju-solutions/interface-monitor.git) | monitor | This interface layer for monitor protocol |
-| [mount](https://github.com/juju-solutions/interface-mount.git) | mount | Interface layer for connecting mounts to a charm such as NFS |
-| [munge-auth](https://github.com/omnivector-solutions/interface-munge-auth) | munge-auth | Interface layer for Munge Auth |
-| [munin-node](https://github.com/freyes/interface-munin-node) | munin-node | munin-node relation |
-| [munin](https://github.com/freyes/interface-munin) | munin | munin relation |
-| [mysql-root](https://github.com/juju-solutions/interface-mysql-root.git) | mysql-root | Administrative MySQL interface with admin access granted to connected applications |
-| [mysql-shared](https://github.com/openstack/charm-interface-mysql-shared) | mysql-shared | MySQL Shared Database interface |
-| [mysql](https://github.com/johnsca/juju-relation-mysql.git) | mysql | Standard MySQL interface with generated, per-service databases |
-| [namenode-cluster](https://github.com/juju-solutions/interface-namenode-cluster.git) | namenode-cluster | Interface layer for running Apache Hadoop NameNode as HA |
-| [neutron-load-balancer](https://github.com/openstack-charmers/charm-interface-neutron-load-balancer.git) | neutron-load-balancer | Interface supporting the integration between Neutron and external Load Balancer services |
-| [neutron-plugin-api-subordinate](https://github.com/openstack/charm-interface-neutron-plugin-api-subordinate) | neutron-plugin-api-subordinate | This interface is used for a charm to send configuration information to the neutron-api principle charm and request a restart of a service managed by that charm. |
-| [neutron-plugin-zlmao](https://github.com/openstack/charm-interface-neutron-plugin) | neutron-plugin | Interface for intergrating Neutron SDN with the nova-compute charm |
-| [neutron-plugin](https://github.com/openstack/charm-interface-neutron-plugin) | neutron-plugin | Interface for intergrating Neutron SDN with the nova-compute charm |
-| [nfsstorage](https://launchpad.net/~ibmcharmers/interface-ibm-nfsstorage/trunk) | nfsstorage | This interface layer handles the communication between LSF/Spectrum Symphony Storage which is acting as a NFS Server and NFS Clients like Platform LSF Master, Spectrum Symphony Master. |
-| [nginx-stats](https://github.com/silph-io/interface-nginx-stats) | NGINX Stats | NGINX stats/status protocol |
-| [nova-cell](https://github.com/openstack-charmers/charm-interface-nova-cell.git) | nova-cell | Interface supporting the integration between Nova super conductor and nova cell |
-| [nova-compute](https://github.com/openstack-charmers/charm-interface-nova-compute.git) | nova-compute | Interface supporting the integration between Nova controller and compute nodes |
-| [nrpe-external-master](https://github.com/cmars/nrpe-external-master-interface) | nrpe-external-master | relation for registering nagios checks |
-| [odl-controller-api](https://github.com/openstack/charm-interface-odl-controller-api) | odl-controller-api | Interface for intergrating with an OpenDayLight Controller RESTful API |
-| [oozie](https://gitlab.com/spiculedata/juju/oozie-interface.git) | oozie | Connection for oozie to consumers |
-| [openstack-ha](https://github.com/openstack/charm-interface-openstack-ha) | openstack-ha | Interface for managing information with peers in the same OpenStack service |
-| [openstack-integration](https://github.com/juju-solutions/interface-openstack-integration.git) | openstack-integration | Interface layer for connecting to the OpenStack integrator charm |
-| [opentsdb](https://github.com/tengu-team/interface-opentsdb.git) | opentsdb | Interface layer for OpenTSDB. |
-| [ovsdb-manager](https://github.com/openstack/charm-interface-ovsdb-manager) | ovsdb-manager | Interface for relating to the OVSDB manager aspect of OpenDayLight SDN |
-| [panko](https://github.com/openstack-charmers/charm-interface-panko) | panko | Panko Event Service interface |
-| [peer-discovery](https://github.com/tbaumann/charm-interface-peer-discovery) | peer-discovery | [proposal] simple interface to discover all peers of a charm through peer relation |
-| [pgsql](https://git.launchpad.net/interface-pgsql) | pgsql | Postgresql database client interface |
-| [platformmaster](https://launchpad.net/~ibmcharmers/interface-ibm-platformmaster/trunk) | platformmaster | This interface layer handles the communication between Platform Master (like IBM Platform LSF, IBM Spectrum Symphony) and Platform Server/Nodes. |
-| [prometheus-rules](https://github.com/CanonicalBootStack/interface-prometheus-rules.git) | prometheus-rules | Relation Stub to export Prometheus alerting rules |
-| [prometheus](https://git.launchpad.net/interface-prometheus) | prometheus | Prometheus target interface |
-| [public-address](https://github.com/juju-solutions/interface-public-address) | public-address | Simple relation that provides the providers public-address and a port |
-| [rabbitmq](https://github.com/openstack/charm-interface-rabbitmq) | rabbitmq | RabbitMQ AMQP interface |
-| [redis](https://github.com/omnivector-solutions/interface-redis) | redis | Interface for relating to redis |
-| [rsyslog](https://bazaar.launchpad.net/~canonical-sysadmins/canonical-is-charms/layer-rsyslog/files) | Rsyslog layer | This rsyslog layer will enable rsyslog and enable building additional logging configuration. |
-| [sdn-plugin](https://github.com/juju-solutions/interface-sdn-plugin) | sdn-plugin | An abstraction of common configurations for SDN providers, to be consumed by charms |
-| [service-control](https://github.com/openstack/charm-interface-service-control) | service-control | This interface is used for a charm to request a restart of a service managed by another charm. |
-| [slurm-cluster](https://github.com/omnivector-solutions/interface-slurm-cluster) | slurm-cluster | Interface layer for Slurm |
-| [slurm-controller-ha](https://github.com/omnivector-solutions/interface-slurm-controller-ha) | slurm-controller-ha | Interface layer for Slurm-Controller-HA |
-| [slurm-dbd-ha](https://github.com/omnivector-solutions/interface-slurm-dbd-ha) | slurm-dbd-ha | Interface layer for Slurm-DBD-HA |
-| [slurm-dbd](https://github.com/omnivector-solutions/interface-slurm-dbd) | slurm-dbd | Interface layer for Slurm-DBD |
-| [solr](https://github.com/buggtb/interface-solr) | solr | Solr Charm Interface |
-| [spark-quorum](https://github.com/juju-solutions/interface-spark-quorum.git) | spark quorum | This interface layer handles the communication among Apache Spark peers |
-| [spark](https://github.com/juju-solutions/interface-spark.git) | spark | Interface layer for the spark interface protocol |
-| [spectrum-scale-client](https://code.launchpad.net/~ibmcharmers/interface-spectrum-scale-client/trunk) | spectrum-scale-client | Basic interface required for communication between Spectrum Scale client and IBM Cinder SpectrumScale (driver for gpfs) |
-| [syslog](https://github.com/juju-solutions/interface-syslog.git) | syslog | Interface layer for the syslog protocol |
-| [tls-certificates](https://github.com/juju-solutions/interface-tls-certificates) | tls-certificates | An interface for exchanging tls certificates using provides and requres relations. |
-| [tls](https://github.com/juju-solutions/interface-tls) | tls | The TLS interface provides a peering relationship to exchange certificates and CSR's. |
-| [vault-kv](https://github.com/openstack-charmers/charm-interface-vault-kv.git) | vault-kv | Interface layer for the vault-kv protocol |
-| [vault](https://github.com/ChrisMacNaughton/juju-interface-vault.git) | vault | Hashicorp Vault omterface |
-| [vsphere-integration](https://github.com/juju-solutions/interface-vsphere-integration.git) | vsphere-integration | Interface layer for connecting to the VMware vSphere integration charm |
-| [was-ihs](https://code.launchpad.net/~ibmcharmers/interface-ibm-was-ihs/trunk) | was-ihs | This Interface handles the communication between IBM WAS Base/IBM WAS ND and IBM Http Server |
-| [was-nd](https://code.launchpad.net/~ibmcharmers/interface-ibm-was-nd/trunk) | was-nd | This interface handles the communication between IBM WAS ND DM and other consumer charms. |
-| [websso-fid-service-provider](https://github.com/dshcherb/charm-interface-websso-fid-service-provider) | websso-fid-service-provider | An interface to connect a federated identity provider to OpenStack dashboard charm |
-| [weebl](https://github.com/autonomouse/interface-weebl) | weebl | Interface for relating to the OIL dashboard (Weebl) |
-| [wsgi](https://git.launchpad.net/~ubuntuone-hackers/charms/+source/interface-wsgi) | wsgi | Basic WSGI interface |
-| [zeppelin](https://github.com/juju-solutions/interface-zeppelin) | zeppelin | Interface layer for interacting with charms for Apache Zeppelin |
-| [zookeeper-quorum](https://github.com/juju-solutions/interface-zookeeper-quorum.git) | zookeeper quorum | This interface layer handles the communication among Apache Zookeeper peers |
-| [zookeeper](https://github.com/juju-solutions/interface-zookeeper.git) | zookeeper | This interface layer handles the communication between Apache Zookeeper and its clients |
+| ID | Repo | Docs | Name | Summary |
+| --- | --- | --- | --- | --- |
+| apache-website | [Repo](https://github.com/juju-solutions/interface-apache-website.git) | [Docs](https://github.com/juju-solutions/interface-apache-website.git#readme) | apache-website | Interface layer for the apache-website interface protocol |
+| arangodb | [Repo](https://github.com/tengu-team/interface-arangodb.git) | [Docs](https://github.com/tengu-team/interface-arangodb.git#readme) | arangodb | Interface layer for ArangoDB |
+| audit | [Repo](https://launchpad.net/~timkuhlman/charm-layer-auditd/audit-interface) | [Docs](https://bazaar.launchpad.net/~timkuhlman/charm-layer-auditd/files/README.md) | audit | Interface for use with the auditd charm |
+| aws-elb | [Repo](https://github.com/omnivector-solutions/interface-aws-elb) | [Docs](https://github.com/omnivector-solutions/interface-aws-elb#readme) | AWS-ELB | AWS-ELB provides and requires interfaces. |
+| aws-integration | [Repo](https://github.com/juju-solutions/interface-aws-integration.git) | [Docs](https://github.com/juju-solutions/interface-aws-integration.git#readme) | aws-integration | Interface layer for connecting to the AWS integration charm |
+| azure-integration | [Repo](https://github.com/juju-solutions/interface-azure-integration.git) | [Docs](https://github.com/juju-solutions/interface-azure-integration.git#readme) | azure-integration | Interface layer for connecting to the Azure integration charm |
+| barbican-hsm | [Repo](https://github.com/openstack/charm-interface-barbican-hsm) | [Docs](https://github.com/openstack/charm-interface-barbican-hsm#readme) | barbican-hsm | Interface supporting the integration between Barbican and HSM devices |
+| barbican-secrets | [Repo](https://github.com/openstack-charmers/charm-interface-barbican-secrets.git) | [Docs](https://github.com/openstack-charmers/charm-interface-barbican-secrets.git#readme) | barbican-secrets | Interface supporting the integration between Barbican and secrets storage plugins |
+| basic-auth-check | [Repo](https://github.com/CanonicalLtd/juju-interface-basic-auth-check) | [Docs](https://github.com/CanonicalLtd/juju-interface-basic-auth-check#readme) | basic-auth-check | Interface for the basic-auth-service to validate HTTP Basic-Auth credentials |
+| benchmark | [Repo](https://github.com/juju-solutions/interface-benchmark.git) | [Docs](https://github.com/juju-solutions/interface-benchmark.git#readme) | benchmark | Interface layer for the benchmark protocol |
+| bgp | [Repo](https://github.com/openstack/charm-interface-bgp.git) | [Docs](https://github.com/openstack/charm-interface-bgp.git#readme) | bgp | Interface layer for exchanging BGP neighbour information between charms |
+| bind-rndc | [Repo](https://github.com/openstack/charm-interface-bind-rndc) | [Docs](https://github.com/openstack/charm-interface-bind-rndc#readme) | BIND RNDC interface | BIND RNDC interface |
+| cassandra | [Repo](https://git.launchpad.net/interface-cassandra) | [Docs](https://git.launchpad.net/tree/README.md) | cassandra | Cassandra database client interface |
+| ceph-admin | [Repo](https://github.com/cholcombe973/juju-interface-ceph-admin) | [Docs](https://github.com/cholcombe973/juju-interface-ceph-admin#readme) | ceph-admin | The admin interface for ceph will provide the user with the ceph admin key |
+| ceph-base | [Repo](https://github.com/openstack/charm-layer-ceph-base) | [Docs](https://github.com/openstack/charm-layer-ceph-base#readme) | Ceph Base Layer | Ceph base layer |
+| ceph-client | [Repo](https://github.com/openstack-charmers/charm-interface-ceph-client) | [Docs](https://github.com/openstack-charmers/charm-interface-ceph-client#readme) | ceph-client | Ceph Client interface |
+| ceph-mds | [Repo](https://github.com/openstack/charm-interface-ceph-mds) | [Docs](https://github.com/openstack/charm-interface-ceph-mds#readme) | ceph-mds | CephFS interface to the MDS relation on ceph-mon |
+| ceph-osd | [Repo](https://github.com/ChrisMacNaughton/juju-interface-ceph-osd) | [Docs](https://github.com/ChrisMacNaughton/juju-interface-ceph-osd#readme) | ceph-osd | ceph osd relation |
+| ceph-radosgw | [Repo](https://github.com/ChrisMacNaughton/juju-interface-ceph-radosgw) | [Docs](https://github.com/ChrisMacNaughton/juju-interface-ceph-radosgw#readme) | ceph-radosgw | Ceph RadosGW interface |
+| ceph | [Repo](https://github.com/ChrisMacNaughton/juju-interface-ceph) | [Docs](https://github.com/ChrisMacNaughton/juju-interface-ceph#readme) | ceph | ceph mon peer interface |
+| charms-ci | [Repo](https://github.com/juju-solutions/interface-charms-ci.git) | [Docs](https://github.com/juju-solutions/interface-charms-ci.git#readme) | charms-ci | Juju charms CI interface |
+| conda | [Repo](https://github.com/omnivector-solutions/interface-conda) | [Docs](https://github.com/omnivector-solutions/interface-conda#readme) | Conda | Conda provides and requires interfaces |
+| conn-check | [Repo](https://git.launchpad.net/~ubuntuone-hackers/conn-check/+git/interface-conn-check) | [Docs](https://git.launchpad.net/~ubuntuone-hackers/conn-check/+git/tree/README.md) | conn-check | conn-check interface |
+| consul-agent | [Repo](https://github.com/ChrisMacNaughton/juju-interface-consul.git) | [Docs](https://github.com/ChrisMacNaughton/juju-interface-consul.git#readme) | consul-agent | Hashicorp Consul |
+| consul | [Repo](https://github.com/juju-solutions/interface-consul) | [Docs](https://github.com/juju-solutions/interface-consul#readme) | consul | Hashicorp Consul |
+| cwr-ci | [Repo](https://github.com/juju-solutions/interface-cwr-ci.git) | [Docs](https://github.com/juju-solutions/interface-cwr-ci.git#readme) | cwr-ci | Interface for relating to Cloud Weather Report (part of the Juju CI system) |
+| dashboard-plugin | [Repo](https://github.com/openstack/charm-interface-dashboard-plugin.git) | [Docs](https://github.com/openstack/charm-interface-dashboard-plugin.git#readme) | dashboard-plugin | This interface is for use with OpenStack Dashboard plugin subordinate charms |
+| db-info | [Repo](https://github.com/omnivector-solutions/interface-db-info) | [Docs](https://github.com/omnivector-solutions/interface-db-info#readme) | DB Info | Ease the process of application <-> application database creds transference. |
+| db2 | [Repo](https://launchpad.net/~ibmcharmers/interface-ibm-db2/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-db2/files/README.md) | db2 | This interface layer handles the communication between  IBM DB2 and Consumer charms. |
+| dbname | [Repo](https://github.com/omnivector-solutions/interface-dbname.git) | [Docs](https://github.com/omnivector-solutions/interface-dbname.git#readme) | DB Name | Interface to coordinate database name between applications. |
+| designate | [Repo](https://github.com/openstack-charmers/charm-interface-designate) | [Docs](https://github.com/openstack-charmers/charm-interface-designate#readme) | designate | Designate DNS as a Service interface |
+| dfs-slave | [Repo](https://github.com/juju-solutions/interface-dfs-slave.git) | [Docs](https://github.com/juju-solutions/interface-dfs-slave.git#readme) | dfs-slave | Interface layer for the DataNode <-> NameNode protocol |
+| dfs | [Repo](https://github.com/juju-solutions/interface-dfs.git) | [Docs](https://github.com/juju-solutions/interface-dfs.git#readme) | dfs | Interface layer for the hdfs interface protocol |
+| dm-node | [Repo](https://code.launchpad.net/~ibmcharmers/interface-ibm-dm-node/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-dm-node/files/README.md) | dm-node | This interface handles the comunication between IBM WAS ND DM and IBM WAS ND Node charms |
+| docker-image-host | [Repo](https://github.com/tengu-team/interface-docker-image-host) | [Docs](https://github.com/tengu-team/interface-docker-image-host#readme) | docker-image-host | Interface to send image to docker host |
+| docker-registry | [Repo](https://github.com/juju-solutions/interface-docker-registry.git) | [Docs](https://github.com/juju-solutions/interface-docker-registry.git#readme) | docker-registry | Interface layer for connecting to the Docker Registry charm |
+| dockerhost | [Repo](https://github.com/juju-solutions/interface-dockerhost) | [Docs](https://github.com/juju-solutions/interface-dockerhost#readme) | dockerhost | Docker connection information for a unit |
+| druid-config | [Repo](https://gitlab.com/spiculedata/juju/druid-config-relation.git) | [Docs](https://gitlab.com/spiculedata/juju/druid-config-relation.git) | Druid Configuration | Configuration layer for Spicule's Druid charms. |
+| elastic-beats | [Repo](https://github.com/juju-solutions/interface-elastic-beats) | [Docs](https://github.com/juju-solutions/interface-elastic-beats#readme) | elastic-beats | Interface for elastic beats |
+| elasticsearch | [Repo](http://github.com/juju-solutions/interface-elasticsearch) | [Docs](http://github.com/juju-solutions/interface-elasticsearch#readme) | elasticsearch | Interface to connect with elasticsearch. |
+| etcd-proxy | [Repo](https://github.com/juju-solutions/interface-etcd-proxy) | [Docs](https://github.com/juju-solutions/interface-etcd-proxy#readme) | etcd-proxy | Do you need etcd as a read/readwrite proxy to a cluster? use this interface. |
+| etcd | [Repo](https://github.com/juju-solutions/interface-etcd) | [Docs](https://github.com/juju-solutions/interface-etcd#readme) | etcd | Interface for relating to etcd |
+| flume-agent | [Repo](https://github.com/juju-solutions/interface-flume-agent.git) | [Docs](https://github.com/juju-solutions/interface-flume-agent.git#readme) | flume-agent | Interface layer for communication between Apache Flume charms |
+| gcp-integration | [Repo](https://github.com/juju-solutions/interface-gcp-integration.git) | [Docs](https://github.com/juju-solutions/interface-gcp-integration.git#readme) | gcp-integration | Interface layer for connecting to the GCP integration charm |
+| generic-ip-port-user-pass | [Repo](https://git.launchpad.net/generic-ip-port-user-pass-charm-interface) | [Docs](https://git.launchpad.net/tree/README.md) | generic-ip-port-user-pass | An interface for reactive charms needing to pass generic IP (or URL), port, username and password data |
+| giraph | [Repo](https://github.com/juju-solutions/interface-giraph) | [Docs](https://github.com/juju-solutions/interface-giraph#readme) | giraph | This interface handles the communication between Apache Giraph and its clients |
+| gluster-fuse | [Repo](https://github.com/cholcombe973/juju-interface-gluster-fuse) | [Docs](https://github.com/cholcombe973/juju-interface-gluster-fuse#readme) | gluster-fuse | Distributed posix storage provided by GlusterFS |
+| gluster-nfs | [Repo](https://github.com/cholcombe973/juju-interface-gluster-client) | [Docs](https://github.com/cholcombe973/juju-interface-gluster-client#readme) | gluster-nfs | Scale out NFS provided by GlusterFS |
+| gluster-peer | [Repo](https://github.com/wolsen/charm-interface-gluster-peer) | [Docs](https://github.com/wolsen/charm-interface-gluster-peer#readme) | gluster-peer | Peer interface for glusterfs nodes |
+| gnocchi | [Repo](https://github.com/openstack-charmers/charm-interface-gnocchi) | [Docs](https://github.com/openstack-charmers/charm-interface-gnocchi#readme) | gnocchi | Gnocchi Metrics Service interface |
+| gpfs | [Repo](https://code.launchpad.net/~ibmcharmers/interface-ibm-gpfs/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-gpfs/files/README.md) | gpfs | Interface layer between IBM Spectrum Scale Manager and IBM Spectrum Scale client as well as peer communication among manager/client units |
+| grafana-source | [Repo](https://git.launchpad.net/interface-grafana-source) | [Docs](https://git.launchpad.net/tree/README.md) | grafana-source | Grafana source |
+| hacluster | [Repo](https://github.com/openstack/charm-interface-hacluster.git) | [Docs](https://github.com/openstack/charm-interface-hacluster.git#readme) | hacluster | hacluster interface for relations with hacluster subordinate charm |
+| hadoop-plugin | [Repo](https://github.com/juju-solutions/interface-hadoop-plugin.git) | [Docs](https://github.com/juju-solutions/interface-hadoop-plugin.git#readme) | hadoop-plugin | Interface for relating to Apache Hadoop |
+| hadoop-rest | [Repo](https://github.com/juju-solutions/interface-hadoop-rest) | [Docs](https://github.com/juju-solutions/interface-hadoop-rest#readme) | hadoop-rest | Interface layer for connecting to hadoop-plugin without installation |
+| hbase-quorum | [Repo](https://github.com/juju-solutions/interface-hbase-quorum.git) | [Docs](https://github.com/juju-solutions/interface-hbase-quorum.git#readme) | hbase quorum | This interface layer handles the communication among Apache HBase peers |
+| hbase | [Repo](https://github.com/juju-solutions/interface-hbase.git) | [Docs](https://github.com/juju-solutions/interface-hbase.git#readme) | hbase | This interface layer handles the communication between Apache HBase and its clients |
+| hive | [Repo](https://github.com/juju-solutions/interface-hive.git) | [Docs](https://github.com/juju-solutions/interface-hive.git#readme) | hive | Interface for relating to Apache Hive |
+| http | [Repo](https://github.com/juju-solutions/interface-http.git) | [Docs](https://github.com/juju-solutions/interface-http.git#readme) | http | HTTP Relation Stub |
+| https | [Repo](https://code.launchpad.net/~ibmcharmers/interface-https/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-https/files/README.md) | https |  Basic HTTPS interface |
+| ibm-db2 | [Repo](https://launchpad.net/~ibmcharmers/interface-ibm-db2/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-db2/files/README.md) | ibm-db2 | This interface layer handles the communication between  IBM DB2 and Consumer charms. |
+| ibm-mq | [Repo](https://code.launchpad.net/~ibmcharmers/interface-ibm-mq/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-mq/files/README.md) | ibm-mq | This interface handles the communication between IBM MQ and other consumer charms. |
+| ibm-wxs | [Repo](https://launchpad.net/~ibmcharmers/interface-ibm-wxs/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-wxs/files/README.md) | ibm-wxs | This interface layer handles the communication between  IBM WXS Catalog charm and other consumer charms, such as IBM WXS Container and IBM WXS Client |
+| ignite-hadoop | [Repo](https://github.com/juju-solutions/interface-ignite-hadoop) | [Docs](https://github.com/juju-solutions/interface-ignite-hadoop#readme) | ignite-hadoop | Minimal interface layer for connecting Apache Ignite-Hadoop to Apache Hadoop slave |
+| influxdb-api | [Repo](https://github.com/ChrisMacNaughton/interface-influxdb-api.git) | [Docs](https://github.com/ChrisMacNaughton/interface-influxdb-api.git#readme) | influxdb-api | InfluxDB Query Interface |
+| java | [Repo](https://github.com/juju-solutions/interface-java.git) | [Docs](https://github.com/juju-solutions/interface-java.git#readme) | java | Interface for relating to subordinate charms providing a Java runtime or JDK |
+| jdbc | [Repo](https://gitlab.com/spiculedata/juju/jdbc-interface.git) | [Docs](https://gitlab.com/spiculedata/juju/jdbc-interface.git) | jdbc | JDBC interface for generic connectivity across databases |
+| jenkins-extension | [Repo](https://github.com/juju-solutions/interface-jenkins-extension.git) | [Docs](https://github.com/juju-solutions/interface-jenkins-extension.git#readme) | jenkins-extension | Admin interface to the jenkins master |
+| jenkins-slave | [Repo](https://github.com/freeekanayaka/interface-jenkins-slave.git) | [Docs](https://github.com/freeekanayaka/interface-jenkins-slave.git#readme) | jenkins-slave | Communication between a Jenkins master and a Jenkins slave |
+| jenkins-zuul | [Repo](https://github.com/freeekanayaka/interface-jenkins-zuul.git) | [Docs](https://github.com/freeekanayaka/interface-jenkins-zuul.git#readme) | jenkins-zuul | communication between a Jenkins master and Zuul Jenkins via the zuul interface |
+| juju-info | [Repo](https://github.com/juju-solutions/interface-juju-info.git) | [Docs](https://github.com/juju-solutions/interface-juju-info.git#readme) | juju-info | Implied interface for subordinates with special behavior. This is not a substitute for a proper relationship interface.  |
+| kafka | [Repo](https://github.com/juju-solutions/interface-kafka.git) | [Docs](https://github.com/juju-solutions/interface-kafka.git#readme) | kafka | Interface layer for communication between Kafka and its clients |
+| kapacitor | [Repo](https://github.com/tengu-team/interface-kapacitor.git) | [Docs](https://github.com/tengu-team/interface-kapacitor.git#readme) | kapacitor | Interface layer for Kapacitor |
+| keystone-admin | [Repo](https://github.com/openstack/charm-interface-keystone-admin) | [Docs](https://github.com/openstack/charm-interface-keystone-admin#readme) | keystone-admin | keystone-admin:identity-admin interface to use shared admin API credentials |
+| keystone-credentials | [Repo](https://github.com/openstack/charm-interface-keystone-credentials) | [Docs](https://github.com/openstack/charm-interface-keystone-credentials#readme) | keystone-credentials | keystone-credentials: Interface for integrating with Keystone identity credentials |
+| keystone-domain-backend | [Repo](https://github.com/openstack-charmers/charm-interface-keystone-domain-backend) | [Docs](https://github.com/openstack-charmers/charm-interface-keystone-domain-backend#readme) | keystone-domain-backend | Interface for integration of subordinate charms providing domain specific identity backends |
+| keystone-fid-service-provider | [Repo](https://github.com/dshcherb/charm-interface-keystone-fid-service-provider) | [Docs](https://github.com/dshcherb/charm-interface-keystone-fid-service-provider#readme) | keystone-fid-service-provider | An interface to connect a federated identity provider to the Keystone charm |
+| keystone | [Repo](https://github.com/openstack/charm-interface-keystone) | [Docs](https://github.com/openstack/charm-interface-keystone#readme) | keystone | Keystone interface |
+| kube-control | [Repo](https://github.com/juju-solutions/interface-kube-control.git) | [Docs](https://github.com/juju-solutions/interface-kube-control.git#readme) | kube-control | master-worker control interface for Kubernetes |
+| kube-dns | [Repo](https://github.com/juju-solutions/interface-kube-dns.git) | [Docs](https://github.com/juju-solutions/interface-kube-dns.git#readme) | kube-dns | Kubernetes DNS Details |
+| kubernetes-cni | [Repo](https://github.com/juju-solutions/interface-kubernetes-cni) | [Docs](https://github.com/juju-solutions/interface-kubernetes-cni#readme) | kubernetes-cni | Interface for relating various CNI implementations |
+| limeds | [Repo](https://github.com/tengu-team/interface-limeds) | [Docs](https://github.com/tengu-team/interface-limeds#readme) | limeds | Interface to connect to LimeDS |
+| livy | [Repo](https://gitlab.com/spiculedata/juju/livy-relation.git) | [Docs](https://gitlab.com/spiculedata/juju/livy-relation.git) | Apache Livy relation | Relation to connect a charm to Apache Livy. |
+| local-monitors | [Repo](https://github.com/cmars/local-monitors-interface) | [Docs](https://github.com/cmars/local-monitors-interface#readme) | local-monitors | relation for registering nagios checks |
+| logstash-client | [Repo](https://github.com/juju-solutions/interface-logstash-client) | [Docs](https://github.com/juju-solutions/interface-logstash-client#readme) | logstash-client | Interface for connecting with logstash based systems. |
+| mahout | [Repo](https://github.com/juju-solutions/interface-mahout) | [Docs](https://github.com/juju-solutions/interface-mahout#readme) | mahout | This interface layer handles the communication between Apache Mahout and its clients |
+| manila-plugin | [Repo](https://github.com/openstack/charm-interface-manila-plugin) | [Docs](https://github.com/openstack/charm-interface-manila-plugin#readme) | manila-plugin | manila-plugin: configuration plugin to allow manila plugins to configure the manila service |
+| mapred-slave | [Repo](https://github.com/juju-solutions/interface-mapred-slave.git) | [Docs](https://github.com/juju-solutions/interface-mapred-slave.git#readme) | mapred-slave | Interface layer for the NodeManager <-> ResourceManager protocol |
+| mapred | [Repo](https://github.com/juju-solutions/interface-mapred.git) | [Docs](https://github.com/juju-solutions/interface-mapred.git#readme) | mapred | Interface for the YARN client protocol |
+| memcache | [Repo](https://github.com/omnivector-solutions/interface-memcache.git) | [Docs](https://github.com/omnivector-solutions/interface-memcache.git#readme) | Memcache | Interface for relating memcache. |
+| midonet-api | [Repo](https://github.com/celebdor/interface-midonet-api.git) | [Docs](https://github.com/celebdor/interface-midonet-api.git#readme) | MidoNet API | MidoNet API interface between provider and consuming charms |
+| mongodb-cluster | [Repo](https://github.com/tkuhlman/juju-relation-mongodb) | [Docs](https://github.com/tkuhlman/juju-relation-mongodb#readme) | mongodb-cluster | relation to connect to a mongo database cluster |
+| mongodb | [Repo](https://github.com/cloud-green/juju-relation-mongodb) | [Docs](https://github.com/cloud-green/juju-relation-mongodb#readme) | mongodb | relation to connect to a mongo database |
+| monitor | [Repo](https://github.com/juju-solutions/interface-monitor.git) | [Docs](https://github.com/juju-solutions/interface-monitor.git#readme) | monitor | This interface layer for monitor protocol |
+| mount | [Repo](https://github.com/juju-solutions/interface-mount.git) | [Docs](https://github.com/juju-solutions/interface-mount.git#readme) | mount | Interface layer for connecting mounts to a charm such as NFS |
+| munge-auth | [Repo](https://github.com/omnivector-solutions/interface-munge-auth) | [Docs](https://github.com/omnivector-solutions/interface-munge-auth#readme) | munge-auth | Interface layer for Munge Auth |
+| munin-node | [Repo](https://github.com/freyes/interface-munin-node) | [Docs](https://github.com/freyes/interface-munin-node#readme) | munin-node | munin-node relation |
+| munin | [Repo](https://github.com/freyes/interface-munin) | [Docs](https://github.com/freyes/interface-munin#readme) | munin | munin relation |
+| mysql-root | [Repo](https://github.com/juju-solutions/interface-mysql-root.git) | [Docs](https://github.com/juju-solutions/interface-mysql-root.git#readme) | mysql-root | Administrative MySQL interface with admin access granted to connected applications |
+| mysql-shared | [Repo](https://github.com/openstack/charm-interface-mysql-shared) | [Docs](https://github.com/openstack/charm-interface-mysql-shared#readme) | mysql-shared | MySQL Shared Database interface |
+| mysql | [Repo](https://github.com/johnsca/juju-relation-mysql.git) | [Docs](https://github.com/johnsca/juju-relation-mysql.git#readme) | mysql | Standard MySQL interface with generated, per-service databases |
+| namenode-cluster | [Repo](https://github.com/juju-solutions/interface-namenode-cluster.git) | [Docs](https://github.com/juju-solutions/interface-namenode-cluster.git#readme) | namenode-cluster | Interface layer for running Apache Hadoop NameNode as HA |
+| neutron-load-balancer | [Repo](https://github.com/openstack-charmers/charm-interface-neutron-load-balancer.git) | [Docs](https://github.com/openstack-charmers/charm-interface-neutron-load-balancer.git#readme) | neutron-load-balancer | Interface supporting the integration between Neutron and external Load Balancer services |
+| neutron-plugin-api-subordinate | [Repo](https://github.com/openstack/charm-interface-neutron-plugin-api-subordinate) | [Docs](https://github.com/openstack/charm-interface-neutron-plugin-api-subordinate#readme) | neutron-plugin-api-subordinate | This interface is used for a charm to send configuration information to the neutron-api principle charm and request a restart of a service managed by that charm. |
+| neutron-plugin-zlmao | [Repo](https://github.com/openstack/charm-interface-neutron-plugin) | [Docs](https://github.com/openstack/charm-interface-neutron-plugin#readme) | neutron-plugin | Interface for intergrating Neutron SDN with the nova-compute charm |
+| neutron-plugin | [Repo](https://github.com/openstack/charm-interface-neutron-plugin) | [Docs](https://github.com/openstack/charm-interface-neutron-plugin#readme) | neutron-plugin | Interface for intergrating Neutron SDN with the nova-compute charm |
+| nfsstorage | [Repo](https://launchpad.net/~ibmcharmers/interface-ibm-nfsstorage/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-nfsstorage/files/README.md) | nfsstorage | This interface layer handles the communication between LSF/Spectrum Symphony Storage which is acting as a NFS Server and NFS Clients like Platform LSF Master, Spectrum Symphony Master. |
+| nginx-stats | [Repo](https://github.com/silph-io/interface-nginx-stats) | [Docs](https://github.com/silph-io/interface-nginx-stats#readme) | NGINX Stats | NGINX stats/status protocol |
+| nova-cell | [Repo](https://github.com/openstack-charmers/charm-interface-nova-cell.git) | [Docs](https://github.com/openstack-charmers/charm-interface-nova-cell.git#readme) | nova-cell | Interface supporting the integration between Nova super conductor and nova cell |
+| nova-compute | [Repo](https://github.com/openstack-charmers/charm-interface-nova-compute.git) | [Docs](https://github.com/openstack-charmers/charm-interface-nova-compute.git#readme) | nova-compute | Interface supporting the integration between Nova controller and compute nodes |
+| nrpe-external-master | [Repo](https://github.com/cmars/nrpe-external-master-interface) | [Docs](https://github.com/cmars/nrpe-external-master-interface#readme) | nrpe-external-master | relation for registering nagios checks |
+| odl-controller-api | [Repo](https://github.com/openstack/charm-interface-odl-controller-api) | [Docs](https://github.com/openstack/charm-interface-odl-controller-api#readme) | odl-controller-api | Interface for intergrating with an OpenDayLight Controller RESTful API |
+| oozie | [Repo](https://gitlab.com/spiculedata/juju/oozie-interface.git) | [Docs](https://gitlab.com/spiculedata/juju/oozie-interface.git) | oozie | Connection for oozie to consumers |
+| openstack-ha | [Repo](https://github.com/openstack/charm-interface-openstack-ha) | [Docs](https://github.com/openstack/charm-interface-openstack-ha#readme) | openstack-ha | Interface for managing information with peers in the same OpenStack service |
+| openstack-integration | [Repo](https://github.com/juju-solutions/interface-openstack-integration.git) | [Docs](https://github.com/juju-solutions/interface-openstack-integration.git#readme) | openstack-integration | Interface layer for connecting to the OpenStack integrator charm |
+| opentsdb | [Repo](https://github.com/tengu-team/interface-opentsdb.git) | [Docs](https://github.com/tengu-team/interface-opentsdb.git#readme) | opentsdb | Interface layer for OpenTSDB. |
+| ovsdb-manager | [Repo](https://github.com/openstack/charm-interface-ovsdb-manager) | [Docs](https://github.com/openstack/charm-interface-ovsdb-manager#readme) | ovsdb-manager | Interface for relating to the OVSDB manager aspect of OpenDayLight SDN |
+| panko | [Repo](https://github.com/openstack-charmers/charm-interface-panko) | [Docs](https://github.com/openstack-charmers/charm-interface-panko#readme) | panko | Panko Event Service interface |
+| peer-discovery | [Repo](https://github.com/tbaumann/charm-interface-peer-discovery) | [Docs](https://github.com/tbaumann/charm-interface-peer-discovery#readme) | peer-discovery | [proposal] simple interface to discover all peers of a charm through peer relation |
+| pgsql | [Repo](https://git.launchpad.net/interface-pgsql) | [Docs](https://git.launchpad.net/tree/README.md) | pgsql | Postgresql database client interface |
+| platformmaster | [Repo](https://launchpad.net/~ibmcharmers/interface-ibm-platformmaster/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-platformmaster/files/README.md) | platformmaster | This interface layer handles the communication between Platform Master (like IBM Platform LSF, IBM Spectrum Symphony) and Platform Server/Nodes. |
+| prometheus-rules | [Repo](https://github.com/CanonicalBootStack/interface-prometheus-rules.git) | [Docs](https://github.com/CanonicalBootStack/interface-prometheus-rules.git#readme) | prometheus-rules | Relation Stub to export Prometheus alerting rules |
+| prometheus | [Repo](https://git.launchpad.net/interface-prometheus) | [Docs](https://git.launchpad.net/tree/README.md) | prometheus | Prometheus target interface |
+| public-address | [Repo](https://github.com/juju-solutions/interface-public-address) | [Docs](https://github.com/juju-solutions/interface-public-address#readme) | public-address | Simple relation that provides the providers public-address and a port |
+| rabbitmq | [Repo](https://github.com/openstack/charm-interface-rabbitmq) | [Docs](https://github.com/openstack/charm-interface-rabbitmq#readme) | rabbitmq | RabbitMQ AMQP interface |
+| redis | [Repo](https://github.com/omnivector-solutions/interface-redis) | [Docs](https://github.com/omnivector-solutions/interface-redis#readme) | redis | Interface for relating to redis |
+| rsyslog | [Repo](https://bazaar.launchpad.net/~canonical-sysadmins/canonical-is-charms/layer-rsyslog/files) | [Docs](https://bazaar.launchpad.net/~canonical-sysadmins/canonical-is-charms/layer-rsyslog/files/README.md) | Rsyslog layer | This rsyslog layer will enable rsyslog and enable building additional logging configuration. |
+| sdn-plugin | [Repo](https://github.com/juju-solutions/interface-sdn-plugin) | [Docs](https://github.com/juju-solutions/interface-sdn-plugin#readme) | sdn-plugin | An abstraction of common configurations for SDN providers, to be consumed by charms |
+| service-control | [Repo](https://github.com/openstack/charm-interface-service-control) | [Docs](https://github.com/openstack/charm-interface-service-control#readme) | service-control | This interface is used for a charm to request a restart of a service managed by another charm. |
+| slurm-cluster | [Repo](https://github.com/omnivector-solutions/interface-slurm-cluster) | [Docs](https://github.com/omnivector-solutions/interface-slurm-cluster#readme) | slurm-cluster | Interface layer for Slurm |
+| slurm-controller-ha | [Repo](https://github.com/omnivector-solutions/interface-slurm-controller-ha) | [Docs](https://github.com/omnivector-solutions/interface-slurm-controller-ha#readme) | slurm-controller-ha | Interface layer for Slurm-Controller-HA |
+| slurm-dbd-ha | [Repo](https://github.com/omnivector-solutions/interface-slurm-dbd-ha) | [Docs](https://github.com/omnivector-solutions/interface-slurm-dbd-ha#readme) | slurm-dbd-ha | Interface layer for Slurm-DBD-HA |
+| slurm-dbd | [Repo](https://github.com/omnivector-solutions/interface-slurm-dbd) | [Docs](https://github.com/omnivector-solutions/interface-slurm-dbd#readme) | slurm-dbd | Interface layer for Slurm-DBD |
+| solr | [Repo](https://github.com/buggtb/interface-solr) | [Docs](https://github.com/buggtb/interface-solr#readme) | solr | Solr Charm Interface |
+| spark-quorum | [Repo](https://github.com/juju-solutions/interface-spark-quorum.git) | [Docs](https://github.com/juju-solutions/interface-spark-quorum.git#readme) | spark quorum | This interface layer handles the communication among Apache Spark peers |
+| spark | [Repo](https://github.com/juju-solutions/interface-spark.git) | [Docs](https://github.com/juju-solutions/interface-spark.git#readme) | spark | Interface layer for the spark interface protocol |
+| spectrum-scale-client | [Repo](https://code.launchpad.net/~ibmcharmers/interface-spectrum-scale-client/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-spectrum-scale-client/files/README.md) | spectrum-scale-client | Basic interface required for communication between Spectrum Scale client and IBM Cinder SpectrumScale (driver for gpfs) |
+| syslog | [Repo](https://github.com/juju-solutions/interface-syslog.git) | [Docs](https://github.com/juju-solutions/interface-syslog.git#readme) | syslog | Interface layer for the syslog protocol |
+| tls-certificates | [Repo](https://github.com/juju-solutions/interface-tls-certificates) | [Docs](https://github.com/juju-solutions/interface-tls-certificates#readme) | tls-certificates | An interface for exchanging tls certificates using provides and requres relations. |
+| tls | [Repo](https://github.com/juju-solutions/interface-tls) | [Docs](https://github.com/juju-solutions/interface-tls#readme) | tls | The TLS interface provides a peering relationship to exchange certificates and CSR's. |
+| vault-kv | [Repo](https://github.com/openstack-charmers/charm-interface-vault-kv.git) | [Docs](https://github.com/openstack-charmers/charm-interface-vault-kv.git#readme) | vault-kv | Interface layer for the vault-kv protocol |
+| vault | [Repo](https://github.com/ChrisMacNaughton/juju-interface-vault.git) | [Docs](https://github.com/ChrisMacNaughton/juju-interface-vault.git#readme) | vault | Hashicorp Vault omterface |
+| vsphere-integration | [Repo](https://github.com/juju-solutions/interface-vsphere-integration.git) | [Docs](https://github.com/juju-solutions/interface-vsphere-integration.git#readme) | vsphere-integration | Interface layer for connecting to the VMware vSphere integration charm |
+| was-ihs | [Repo](https://code.launchpad.net/~ibmcharmers/interface-ibm-was-ihs/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-was-ihs/files/README.md) | was-ihs | This Interface handles the communication between IBM WAS Base/IBM WAS ND and IBM Http Server |
+| was-nd | [Repo](https://code.launchpad.net/~ibmcharmers/interface-ibm-was-nd/trunk) | [Docs](https://bazaar.launchpad.net/~ibmcharmers/interface-ibm-was-nd/files/README.md) | was-nd | This interface handles the communication between IBM WAS ND DM and other consumer charms. |
+| websso-fid-service-provider | [Repo](https://github.com/dshcherb/charm-interface-websso-fid-service-provider) | [Docs](https://github.com/dshcherb/charm-interface-websso-fid-service-provider#readme) | websso-fid-service-provider | An interface to connect a federated identity provider to OpenStack dashboard charm |
+| weebl | [Repo](https://github.com/autonomouse/interface-weebl) | [Docs](https://github.com/autonomouse/interface-weebl#readme) | weebl | Interface for relating to the OIL dashboard (Weebl) |
+| wsgi | [Repo](https://git.launchpad.net/~ubuntuone-hackers/charms/+source/interface-wsgi) | [Docs](https://git.launchpad.net/~ubuntuone-hackers/charms/+source/tree/README.md) | wsgi | Basic WSGI interface |
+| zeppelin | [Repo](https://github.com/juju-solutions/interface-zeppelin) | [Docs](https://github.com/juju-solutions/interface-zeppelin#readme) | zeppelin | Interface layer for interacting with charms for Apache Zeppelin |
+| zookeeper-quorum | [Repo](https://github.com/juju-solutions/interface-zookeeper-quorum.git) | [Docs](https://github.com/juju-solutions/interface-zookeeper-quorum.git#readme) | zookeeper quorum | This interface layer handles the communication among Apache Zookeeper peers |
+| zookeeper | [Repo](https://github.com/juju-solutions/interface-zookeeper.git) | [Docs](https://github.com/juju-solutions/interface-zookeeper.git#readme) | zookeeper | This interface layer handles the communication between Apache Zookeeper and its clients |
 
 <!-- /list-of-interfaces -->

--- a/interfaces/elasticsearch.json
+++ b/interfaces/elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "id": "elasticsearch",
   "name": "elasticsearch",
-  "repo": "http://github.com/juju-solutions/interface-elasticsearch ",
+  "repo": "http://github.com/juju-solutions/interface-elasticsearch",
   "summary": "Interface to connect with elasticsearch."
 }

--- a/layers/apt.json
+++ b/layers/apt.json
@@ -2,5 +2,6 @@
   "id": "apt",
   "name": "Apt layer",
   "repo": "https://git.launchpad.net/layer-apt",
+  "docs": "https://github.com/stub42/layer-apt#readme",
   "summary": "Easily deal with apt sources and deb packages"
 }

--- a/update_readme.py
+++ b/update_readme.py
@@ -2,6 +2,30 @@
 
 import json
 from pathlib import Path
+from urllib.parse import urlparse, urljoin, urlunparse
+
+
+def set_default_docs_link(layer):
+    if 'docs' in layer:
+        return
+    repo = layer['repo']
+    repo_parsed = urlparse(repo)
+    netloc = repo_parsed.netloc
+    docs = None
+    if netloc == 'github.com':
+        docs = urljoin(repo, '#readme')
+    elif netloc == 'git.launchpad.net':
+        docs = urljoin(repo, 'tree/README.md')
+    elif netloc in ('code.launchpad.net', 'launchpad.net'):
+        docs = urljoin(
+            urlunparse(repo_parsed._replace(netloc='bazaar.launchpad.net')),
+            'files/README.md')
+    elif netloc == 'bazaar.launchpad.net':
+        docs = urljoin(repo, 'files/README.md')
+    else:
+        docs = repo
+    layer['docs'] = docs
+
 
 readme_file = Path('README.md')
 readme = readme_file.read_text().splitlines()
@@ -11,13 +35,18 @@ for layer_type in ('layers', 'interfaces'):
     end = readme.index('<!-- /list-of-{} -->'.format(layer_type))
     del readme[start+1:end]
     readme.insert(start+1, '')
-    readme.insert(start+2, '| ID | Name | Summary |')
-    readme.insert(start+3, '| --- | --- | --- |')
+    readme.insert(start+2, '| ID | Repo | Docs | Name | Summary |')
+    readme.insert(start+3, '| --- | --- | --- | --- | --- |')
     for layer_file in sorted(Path(layer_type).glob('*.json')):
         end = readme.index('<!-- /list-of-{} -->'.format(layer_type))
         layer = json.loads(layer_file.read_text())
-        readme.insert(
-            end, '| [{id}]({repo}) | {name} | {summary} |'.format(**layer))
+        set_default_docs_link(layer)
+        readme.insert(end,
+                      '| {id} '
+                      '| [Repo]({repo}) '
+                      '| [Docs]({docs}) '
+                      '| {name} '
+                      '| {summary} |'.format(**layer))
     readme.insert(end+1, '')
 
 readme_file.write_text(''.join('{}\n'.format(l) for l in readme))


### PR DESCRIPTION
From the discussion for #59, it seems that being able to specify a docs link which is independent from the repo link would be helpful.  Additionally, this makes the "Docs" link more explicit and obvious in the README.