### PR TITLE
Add Logrotate layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ List of Base Layers
 | layer-debug | [Repo](https://github.com/charms/layer-debug.git) | [Docs](https://github.com/charms/layer-debug.git#readme) | debug | Provides a troubleshooting debug action |
 | leadership | [Repo](https://git.launchpad.net/layer-leadership) | [Docs](https://git.launchpad.net/tree/README.md) | Leadership layer | Help reactive framework charms deal with Juju leadership |
 | lets-encrypt | [Repo](https://github.com/cmars/layer-lets-encrypt) | [Docs](https://github.com/cmars/layer-lets-encrypt#readme) | lets-encrypt | Automatic Let's Encrypt registration for Juju charms, just set the fqdn |
+| Logrotate | [Repo](https://github.com/tbaumann/charm-layer-logrotate) | [Docs](https://github.com/tbaumann/charm-layer-logrotate#readme) | Logrotate layer | Logrotate layer to add logrotate entries in charms |
 | lxd-proxy | [Repo](https://github.com/omnivector-solutions/layer-lxd-proxy) | [Docs](https://github.com/omnivector-solutions/layer-lxd-proxy#readme) | LXD Proxy | iptables proxy that adds and removes PREROUTING rules to ease host -> container proxying with juju |
 | memcache-client | [Repo](https://github.com/omnivector-solutions/layer-memcache-client) | [Docs](https://github.com/omnivector-solutions/layer-memcache-client#readme) | Memcache Client | Client layer for Memcache |
 | metrics | [Repo](https://github.com/CanonicalLtd/layer-metrics) | [Docs](https://github.com/CanonicalLtd/layer-metrics#readme) | Metrics Layer | Reactive charm layer supporting Juju metrics collection |

--- a/layers/logrotate.json
+++ b/layers/logrotate.json
@@ -1,0 +1,6 @@
+{
+  "id": "Logrotate",
+  "name": "Logrotate layer",
+  "repo": "https://github.com/tbaumann/charm-layer-logrotate",
+  "summary": "Logrotate layer to add logrotate entries in charms"
+}


### PR DESCRIPTION
Adding a simple logrotate layer


Please make sure you do the following when updating the layer index:

* [x] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [x] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README
