### PR TITLE
Updating mongodb-cluster to point at a new (temporary) repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ List of Interface Layers
 | mapred | [Repo](https://github.com/juju-solutions/interface-mapred.git) | [Docs](https://github.com/juju-solutions/interface-mapred.git#readme) | mapred | Interface for the YARN client protocol |
 | memcache | [Repo](https://github.com/omnivector-solutions/interface-memcache.git) | [Docs](https://github.com/omnivector-solutions/interface-memcache.git#readme) | Memcache | Interface for relating memcache. |
 | midonet-api | [Repo](https://github.com/celebdor/interface-midonet-api.git) | [Docs](https://github.com/celebdor/interface-midonet-api.git#readme) | MidoNet API | MidoNet API interface between provider and consuming charms |
-| mongodb-cluster | [Repo](https://github.com/tkuhlman/juju-relation-mongodb) | [Docs](https://github.com/tkuhlman/juju-relation-mongodb#readme) | mongodb-cluster | relation to connect to a mongo database cluster |
+| mongodb-cluster | [Repo](https://github.com/Vultaire/juju-relation-mongodb) | [Docs](https://github.com/Vultaire/juju-relation-mongodb#readme) | mongodb-cluster | relation to connect to a mongo database cluster |
 | mongodb | [Repo](https://github.com/cloud-green/juju-relation-mongodb) | [Docs](https://github.com/cloud-green/juju-relation-mongodb#readme) | mongodb | relation to connect to a mongo database |
 | monitor | [Repo](https://github.com/juju-solutions/interface-monitor.git) | [Docs](https://github.com/juju-solutions/interface-monitor.git#readme) | monitor | This interface layer for monitor protocol |
 | mount | [Repo](https://github.com/juju-solutions/interface-mount.git) | [Docs](https://github.com/juju-solutions/interface-mount.git#readme) | mount | Interface layer for connecting mounts to a charm such as NFS |

--- a/interfaces/mongodb-cluster.json
+++ b/interfaces/mongodb-cluster.json
@@ -1,6 +1,6 @@
 {
   "id": "mongodb-cluster",
   "name": "mongodb-cluster",
-  "repo": "https://github.com/tkuhlman/juju-relation-mongodb",
+  "repo": "https://github.com/Vultaire/juju-relation-mongodb",
   "summary": "relation to connect to a mongo database cluster"
 }


### PR DESCRIPTION
Note: the new repo is the same as the old one, except for one new
commit which should probably be reviewed:
437400fb462e636e9174e28ac2872296d9d29e86