### PR TITLE
Fix broken coordinator docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ List of Base Layers
 | conda-api | [Repo](https://github.com/omnivector-solutions/layer-conda-api) | [Docs](https://github.com/omnivector-solutions/layer-conda-api#readme) | Conda API | Conda API layer |
 | consul-base | [Repo](https://github.com/omnivector-solutions/layer-consul-base) | [Docs](https://github.com/omnivector-solutions/layer-consul-base#readme) | Consul Base | Reactive base layer for consul |
 | container-runtime-common | [Repo](https://github.com/charmed-kubernetes/layer-container-runtime-common.git) | [Docs](https://github.com/charmed-kubernetes/layer-container-runtime-common.git#readme) | Container Runtime Common | Shared between container runtimes |
-| coordinator | [Repo](https://git.launchpad.net/layer-coordinator ) | [Docs](https://git.launchpad.net/tree/README.md) | Coordinator Layer | Coordinate operations between units in a service, such as rolling restarts. |
+| coordinator | [Repo](https://git.launchpad.net/layer-coordinator ) | [Docs](https://git.launchpad.net/layer-coordinator/tree/README.md) | Coordinator Layer | Coordinate operations between units in a service, such as rolling restarts. |
 | debug | [Repo](https://github.com/juju-solutions/layer-debug.git) | [Docs](https://github.com/juju-solutions/layer-debug.git#readme) | debug | Provides a troubleshooting debug action |
 | django | [Repo](https://github.com/marcoceppi/layer-django.git) | [Docs](https://github.com/marcoceppi/layer-django.git#readme) | Django | Django / GUNICORN |
 | docker-resource | [Repo](https://github.com/juju-solutions/layer-docker-resource.git) | [Docs](https://github.com/juju-solutions/layer-docker-resource.git#readme) | Docker Resource Layer | Layer for managing charm resources of type 'docker' |

--- a/layers/coordinator.json
+++ b/layers/coordinator.json
@@ -2,5 +2,6 @@
   "id": "coordinator",
   "name": "Coordinator Layer",
   "repo": "https://git.launchpad.net/layer-coordinator ",
-  "summary": "Coordinate operations between units in a service, such as rolling restarts."
+  "summary": "Coordinate operations between units in a service, such as rolling restarts.",
+  "docs": "https://git.launchpad.net/layer-coordinator/tree/README.md"
 }

--- a/layers/snap.json
+++ b/layers/snap.json
@@ -2,5 +2,6 @@
   "id": "snap",
   "name": "Snap layer",
   "repo": "https://git.launchpad.net/layer-snap",
-  "summary": "Snap layer for installing and updating Snap packages"
+  "summary": "Snap layer for installing and updating Snap packages",
+  "docs": "https://git.launchpad.net/layer-snap/tree/README.md"
 }


### PR DESCRIPTION
fixes #96

Please make sure you do the following when updating the layer index:

* [x] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [x] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README
