### PR TITLE
adding CIS Benchmark base layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ List of Base Layers
 | ceph-mon | [Repo](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon) | [Docs](https://github.com/ChrisMacNaughton/juju-layer-ceph-mon#readme) | EXPERIMENTAL Ceph Mon layer | EXPERIMENTAL Ceph Mon layer |
 | ceph | [Repo](https://github.com/openstack/charm-layer-ceph.git) | [Docs](https://github.com/openstack/charm-layer-ceph.git#readme) | Ceph Layer | Ceph base layer |
 | charmscaler-base | [Repo](https://github.com/elastisys/layer-charmscaler-base) | [Docs](https://github.com/elastisys/layer-charmscaler-base#readme) | Charmscaler Base | Charmscaler base layer |
+| cis-benchmark | [Repo](https://github.com/charmed-kubernetes/layer-cis-benchmark) | [Docs](https://github.com/charmed-kubernetes/layer-cis-benchmark#readme) | CIS Benchmark base layer | Provides a cis-benchmark action for the CIS Kubernetes benchmark. |
 | conda-api | [Repo](https://github.com/omnivector-solutions/layer-conda-api) | [Docs](https://github.com/omnivector-solutions/layer-conda-api#readme) | Conda API | Conda API layer |
 | consul-base | [Repo](https://github.com/omnivector-solutions/layer-consul-base) | [Docs](https://github.com/omnivector-solutions/layer-consul-base#readme) | Consul Base | Reactive base layer for consul |
 | container-runtime-common | [Repo](https://github.com/charmed-kubernetes/layer-container-runtime-common.git) | [Docs](https://github.com/charmed-kubernetes/layer-container-runtime-common.git#readme) | Container Runtime Common | Shared between container runtimes |

--- a/layers/cis-benchmark.json
+++ b/layers/cis-benchmark.json
@@ -1,0 +1,6 @@
+{
+  "id": "cis-benchmark",
+  "name": "CIS Benchmark base layer",
+  "repo": "https://github.com/charmed-kubernetes/layer-cis-benchmark",
+  "summary": "Provides a cis-benchmark action for the CIS Kubernetes benchmark."
+}


### PR DESCRIPTION
Please make sure you do the following when updating the layer index:

* [x] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [x] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README

Currently only includes the CIS K8s benchmark, though this could be expanded for other CIS benchmarks in the future.