### PR TITLE
add kubernetes-master peer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ List of Interface Layers
 | keystone | [Repo](https://github.com/openstack/charm-interface-keystone) | [Docs](https://github.com/openstack/charm-interface-keystone#readme) | keystone | Keystone interface |
 | kube-control | [Repo](https://github.com/juju-solutions/interface-kube-control.git) | [Docs](https://github.com/juju-solutions/interface-kube-control.git#readme) | kube-control | master-worker control interface for Kubernetes |
 | kube-dns | [Repo](https://github.com/juju-solutions/interface-kube-dns.git) | [Docs](https://github.com/juju-solutions/interface-kube-dns.git#readme) | kube-dns | Kubernetes DNS Details |
+| kube-masters | [Repo](https://github.com/charmed-kubernetes/interface-kube-masters.git) | [Docs](https://github.com/charmed-kubernetes/interface-kube-masters.git#readme) | Kubernetes Master Peers | Interface for kubernetes-master peers |
 | kubernetes-cni | [Repo](https://github.com/juju-solutions/interface-kubernetes-cni) | [Docs](https://github.com/juju-solutions/interface-kubernetes-cni#readme) | kubernetes-cni | Interface for relating various CNI implementations |
 | limeds | [Repo](https://github.com/tengu-team/interface-limeds) | [Docs](https://github.com/tengu-team/interface-limeds#readme) | limeds | Interface to connect to LimeDS |
 | livy | [Repo](https://gitlab.com/spiculedata/juju/livy-relation.git) | [Docs](https://gitlab.com/spiculedata/juju/livy-relation.git) | Apache Livy relation | Relation to connect a charm to Apache Livy. |

--- a/interfaces/kube-masters.json
+++ b/interfaces/kube-masters.json
@@ -1,0 +1,6 @@
+{
+  "id": "kube-masters",
+  "name": "Kubernetes Master Peers",
+  "repo": "https://github.com/charmed-kubernetes/interface-kube-masters.git",
+  "summary": "Interface for kubernetes-master peers"
+}


### PR DESCRIPTION
Please make sure you do the following when updating the layer index:

* [x] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [x] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README
