### PR TITLE
Layer projects have moved to canonical org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ List of Base Layers
 | Logrotate | [Repo](https://github.com/tbaumann/charm-layer-logrotate) | [Docs](https://github.com/tbaumann/charm-layer-logrotate#readme) | Logrotate layer | Logrotate layer to add logrotate entries in charms |
 | lxd-proxy | [Repo](https://github.com/omnivector-solutions/layer-lxd-proxy) | [Docs](https://github.com/omnivector-solutions/layer-lxd-proxy#readme) | LXD Proxy | iptables proxy that adds and removes PREROUTING rules to ease host -> container proxying with juju |
 | memcache-client | [Repo](https://github.com/omnivector-solutions/layer-memcache-client) | [Docs](https://github.com/omnivector-solutions/layer-memcache-client#readme) | Memcache Client | Client layer for Memcache |
-| meter-status | [Repo](https://github.com/CanonicalLtd/layer-meter-status) | [Docs](https://github.com/CanonicalLtd/layer-meter-status#readme) | Meter Status Layer | Reactive charm layer supporting Juju meter status hooks |
-| metrics | [Repo](https://github.com/CanonicalLtd/layer-metrics) | [Docs](https://github.com/CanonicalLtd/layer-metrics#readme) | Metrics Layer | Reactive charm layer supporting Juju metrics collection |
+| meter-status | [Repo](https://github.com/canonical/layer-meter-status) | [Docs](https://github.com/canonical/layer-meter-status#readme) | Meter Status Layer | Reactive charm layer supporting Juju meter status hooks |
+| metrics | [Repo](https://github.com/canonical/layer-metrics) | [Docs](https://github.com/canonical/layer-metrics#readme) | Metrics Layer | Reactive charm layer supporting Juju metrics collection |
 | munge | [Repo](https://github.com/omnivector-solutions/layer-munge) | [Docs](https://github.com/omnivector-solutions/layer-munge#readme) | munge | Reactive layer for Munge authentication service. |
 | munin | [Repo](https://github.com/freyes/layer-munin) | [Docs](https://github.com/freyes/layer-munin#readme) | munin | munin server |
 | nagios | [Repo](https://git.launchpad.net/nagios-layer) | [Docs](https://git.launchpad.net/tree/README.md) | Nagios Layer | Provide boilerplate required to relate services to the cs:nrpe subordinate |

--- a/layers/meter-status.json
+++ b/layers/meter-status.json
@@ -1,6 +1,6 @@
 {
   "id": "meter-status",
   "name": "Meter Status Layer",
-  "repo": "https://github.com/CanonicalLtd/layer-meter-status",
+  "repo": "https://github.com/canonical/layer-meter-status",
   "summary": "Reactive charm layer supporting Juju meter status hooks"
 }

--- a/layers/metrics.json
+++ b/layers/metrics.json
@@ -1,6 +1,6 @@
 {
   "id": "metrics",
   "name": "Metrics Layer",
-  "repo": "https://github.com/CanonicalLtd/layer-metrics",
+  "repo": "https://github.com/canonical/layer-metrics",
   "summary": "Reactive charm layer supporting Juju metrics collection"
 }


### PR DESCRIPTION
Please make sure you do the following when updating the layer index:

* [X] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [ ] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README
