### PR TITLE
Add bind-client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ List of Interface Layers
 | basic-auth-check | [Repo](https://github.com/CanonicalLtd/juju-interface-basic-auth-check) | [Docs](https://github.com/CanonicalLtd/juju-interface-basic-auth-check#readme) | basic-auth-check | Interface for the basic-auth-service to validate HTTP Basic-Auth credentials |
 | benchmark | [Repo](https://github.com/juju-solutions/interface-benchmark.git) | [Docs](https://github.com/juju-solutions/interface-benchmark.git#readme) | benchmark | Interface layer for the benchmark protocol |
 | bgp | [Repo](https://github.com/openstack/charm-interface-bgp.git) | [Docs](https://github.com/openstack/charm-interface-bgp.git#readme) | bgp | Interface layer for exchanging BGP neighbour information between charms |
+| bind-client | [Repo](https://github.com/canonical/interface-bind-client) | [Docs](https://github.com/canonical/interface-bind-client#readme) | BIND CLIENT interface | BIND CLIENT interface |
 | bind-rndc | [Repo](https://github.com/openstack/charm-interface-bind-rndc) | [Docs](https://github.com/openstack/charm-interface-bind-rndc#readme) | BIND RNDC interface | BIND RNDC interface |
 | cassandra | [Repo](https://git.launchpad.net/interface-cassandra) | [Docs](https://git.launchpad.net/tree/README.md) | cassandra | Cassandra database client interface |
 | ceph-admin | [Repo](https://github.com/openstack-charmers/juju-interface-ceph-admin) | [Docs](https://github.com/openstack-charmers/juju-interface-ceph-admin#readme) | ceph-admin | EXPERIMENTAL: The admin interface for ceph will provide the user with the ceph admin key |

--- a/interfaces/bind-client.json
+++ b/interfaces/bind-client.json
@@ -1,0 +1,6 @@
+{
+    "id": "bind-client",
+    "name": "BIND CLIENT interface",
+    "repo": "https://github.com/canonical/interface-bind-client",
+    "summary": "BIND CLIENT interface"
+}


### PR DESCRIPTION
Add bind-client interface that can be used on  the relation between `charm-designate-bind` and `prometheus-bind-exporter-operator`

Please make sure you do the following when updating the layer index:

* [x] Add or update the JSON file for your layer, in the appropriate subdirectory (`layers` or `interfaces`)
* [x] Add an explicit `docs` URL field to your JSON, if appropriate.  If omitted, it will default to the `README.md` at the root of your repo, but you may want to provide a more specific URL.  If you're using the `subdir` field, then you definitely want to point to the README of the layer rather than the repo.
* [x] Run `update_readme.py` to update the user-friendly index in the README
